### PR TITLE
Add support for React stateless components

### DIFF
--- a/src/js/utils/ReactComponentHandler.js
+++ b/src/js/utils/ReactComponentHandler.js
@@ -30,11 +30,16 @@ lm.utils.copy( lm.utils.ReactComponentHandler.prototype, {
 	 */
 	_render: function() {
 		this._reactComponent = ReactDOM.render( this._getReactComponent(), this._container.getElement()[ 0 ] );
-		this._originalComponentWillUpdate = this._reactComponent.componentWillUpdate || function() {
-			};
-		this._reactComponent.componentWillUpdate = this._onUpdate.bind( this );
-		if( this._container.getState() ) {
-			this._reactComponent.setState( this._container.getState() );
+		if ( this._reactComponent ) {
+			/* Stateful React component */
+			this._originalComponentWillUpdate = this._reactComponent.componentWillUpdate || function() {
+				};
+			this._reactComponent.componentWillUpdate = this._onUpdate.bind( this );
+			if( this._container.getState() ) {
+				this._reactComponent.setState( this._container.getState() );
+			}
+		} else {
+			/* Stateless React component, nothing to do */
 		}
 	},
 
@@ -59,7 +64,9 @@ lm.utils.copy( lm.utils.ReactComponentHandler.prototype, {
 	 */
 	_onUpdate: function( nextProps, nextState ) {
 		this._container.setState( nextState );
-		this._originalComponentWillUpdate.call( this._reactComponent, nextProps, nextState );
+		if ( this._originalComponentWillUpdate ) {
+			this._originalComponentWillUpdate.call( this._reactComponent, nextProps, nextState );
+		}
 	},
 
 	/**


### PR DESCRIPTION
This pull request adds support for React stateless components in `utils/ReactComponentHandler.js`.

The present implementation assumes that `ReactDOM.render()` returns the rendered component, which is true only if the rendered component is a stateful class-based React component. `ReactDOM.render()` will return `null` instead if the rendered component is stateless. The PR modifies `ReactComponentHandler` so this is detected and handled accordingly.

For what it's worth, the React documentation states that the return value of `ReactDOM.render()` should not be relied on as React might switch to asynchronous rendering in the future, in which case ReactDOM will return nothing. Another pull request might follow in a few weeks where I tackle this issue specifically.