### PR TITLE
added removeDragSource() method to layout manager

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -134,8 +134,17 @@ declare module 'golden-layout' {
          * where it turns into a contentItem.
          * @param element The DOM element that will be turned into a dragSource
          * @param itemConfiguration An item configuration (can be an entire tree of items)
+         * @return the dragSource that was created. This can be used to remove the
+         *         dragSource from the layout later.
          */
-        createDragSource(element: HTMLElement | JQuery, itemConfiguration: GoldenLayout.ItemConfigType): void;
+        createDragSource(element: HTMLElement | JQuery, itemConfiguration: GoldenLayout.ItemConfigType): GoldenLayout.DragSource;
+
+        /**
+         * Removes a dragSource from the layout.
+         *
+         * @param dragSource The dragSource to remove
+         */
+        removeDragSource(dragSource: GoldenLayout.DragSource): void;
 
         /**
          * If settings.selectionEnabled is set to true, this allows to select items programmatically.
@@ -694,6 +703,9 @@ declare module 'golden-layout' {
              * Closes the container or returns false if that is not possible
              */
             close(): boolean;
+        }
+
+        export interface DragSource {
         }
 
         export interface BrowserWindow {

--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -491,7 +491,9 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 	 * @param   {jQuery DOM element} element
 	 * @param   {Object|Function} itemConfig for the new item to be created, or a function which will provide it
 	 *
-	 * @returns {void}
+	 * @returns {DragSource}  an opaque object that identifies the DOM element
+	 *          and the attached itemConfig. This can be used in
+	 *          removeDragSource() later to get rid of the drag listeners.
 	 */
 	createDragSource: function( element, itemConfig ) {
 		this.config.settings.constrainDragToContainer = false;
@@ -499,6 +501,19 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 		this._dragSources.push( dragSource );
 
 		return dragSource;
+	},
+
+	/**
+	 * Removes a DragListener added by createDragSource() so the corresponding
+	 * DOM element is not a drag source any more.
+	 *
+	 * @param   {jQuery DOM element} element
+	 *
+	 * @returns {void}
+	 */
+	removeDragSource: function( dragSource ) {
+		dragSource.destroy();
+		lm.utils.removeFromArray( dragSource, this._dragSources );
 	},
 
 	/**

--- a/src/js/controls/DragSource.js
+++ b/src/js/controls/DragSource.js
@@ -20,14 +20,21 @@ lm.controls.DragSource = function( element, itemConfig, layoutManager ) {
 lm.utils.copy( lm.controls.DragSource.prototype, {
 
 	/**
+	 * Disposes of the drag listeners so the drag source is not usable any more.
+	 *
+	 * @returns {void}
+	 */
+	destroy: function() {
+		this._removeDragListener();
+	},
+
+	/**
 	 * Called initially and after every drag
 	 *
 	 * @returns {void}
 	 */
 	_createDragListener: function() {
-		if( this._dragListener !== null ) {
-			this._dragListener.destroy();
-		}
+		this._removeDragListener();
 
 		this._dragListener = new lm.utils.DragListener( this._element );
 		this._dragListener.on( 'dragStart', this._onDragStart, this );
@@ -51,5 +58,17 @@ lm.utils.copy( lm.controls.DragSource.prototype, {
 			dragProxy = new lm.controls.DragProxy( x, y, this._dragListener, this._layoutManager, contentItem, null );
 
 		this._layoutManager.transitionIndicator.transitionElements( this._element, dragProxy.element );
+	},
+
+	/**
+	 * Called after every drag and when the drag source is being disposed of.
+	 *
+	 * @returns {void}
+	 */
+	_removeDragListener: function() {
+		if( this._dragListener !== null ) {
+			this._dragListener.destroy();
+		}
 	}
+
 } );


### PR DESCRIPTION
This pull request adds a `removeDragSource()` method to the layout manager that can be used to clean up after ourselves when a drag source added with `createDragSource()` is needed no longer.

This can be used in React to create a component that contains multiple drag sources as we need to ensure that the drag sources are no longer registered in the layout manager when the component is unmounted in React.

The pull request also fixes a typing error in `index.d.ts` where `createDragSource()` was incorrectly reported to return `void`.