### PR TITLE
fix for broken Non Drop Stack example #357

### DIFF
--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -654,7 +654,10 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 				this._itemAreas.push( area );
 				var header = {};
 				lm.utils.copy( header, area );
-				lm.utils.copy( header, area.contentItem._contentAreaDimensions.header.highlightArea );
+				var dimsHeader = area.contentItem._contentAreaDimensions.header;
+				if (dimsHeader && dimsHeader.highlightArea) {
+					lm.utils.copy( header, dimsHeader.highlightArea );
+				}
 				header.surface = ( header.x2 - header.x1 ) * ( header.y2 - header.y1 );
 				this._itemAreas.push( header );
 			}


### PR DESCRIPTION
In [Non Drop Stack example](http://golden-layout.com/examples/#30979a043f34750045dbe57aba4b1ee5), this code handles the non-drop zone:

```
myLayout.on( 'initialised', function(){
  var noDropStack = myLayout.root.getItemsById( 'no-drop-target' )[ 0 ];
  var originalGetArea = noDropStack._$getArea;
  noDropStack._$getArea = function() {
    var area = originalGetArea.call( noDropStack );
    delete noDropStack._contentAreaDimensions.header;
    return area;
  };
});
```

The part that is creating the bug is `delete noDropStack._contentAreaDimensions.header;`.
For this reason, I added a check to make sure this variable is not `undefined`.