### PR TITLE
 Add setting for disabling stacking globally or on individual stacks.

### DIFF
--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -654,9 +654,12 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 				this._itemAreas.push( area );
 				var header = {};
 				lm.utils.copy( header, area );
-				lm.utils.copy( header, area.contentItem._contentAreaDimensions.header.highlightArea );
-				header.surface = ( header.x2 - header.x1 ) * ( header.y2 - header.y1 );
-				this._itemAreas.push( header );
+				var dimsHeader = area.contentItem._contentAreaDimensions.header;
+				if (dimsHeader && dimsHeader.highlightArea) {
+					lm.utils.copy( header, dimsHeader.highlightArea );
+					header.surface = ( header.x2 - header.x1 ) * ( header.y2 - header.y1 );
+					this._itemAreas.push( header );
+				}
 			}
 		}
 	},

--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -1016,7 +1016,8 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 	 * @returns {bool} - True if responsive layout should be used; otherwise false.
 	 */
 	_useResponsiveLayout: function() {
-		return this.config.settings && ( this.config.settings.responsiveMode == 'always' || ( this.config.settings.responsiveMode == 'onload' && this._firstLoad ) );
+		return this.config.settings && this.config.settings.stackingEnabled !== false
+				&& ( this.config.settings.responsiveMode == 'always' || ( this.config.settings.responsiveMode == 'onload' && this._firstLoad ) );
 	},
 
 	/**

--- a/src/js/config/defaultConfig.js
+++ b/src/js/config/defaultConfig.js
@@ -5,6 +5,7 @@ lm.config.defaultConfig = {
 		constrainDragToContainer: true,
 		reorderEnabled: true,
 		selectionEnabled: false,
+		stackingEnabled: true,
 		popoutWholeStack: false,
 		blockedPopoutsThrowError: true,
 		closePopoutsOnUnload: true,

--- a/src/js/controls/BrowserPopout.js
+++ b/src/js/controls/BrowserPopout.js
@@ -96,7 +96,19 @@ lm.utils.copy( lm.controls.BrowserPopout.prototype, {
 			 */
 			if( !parentItem ) {
 				if( this._layoutManager.root.contentItems.length > 0 ) {
-					parentItem = this._layoutManager.root.contentItems[ 0 ];
+					var topItem = this._layoutManager.root.contentItems[ 0 ];
+
+					/*
+					 * If the topmost item is a stack, and we can't add another item
+					 *  because stacking in it is disabled, put both items in a new row
+					 */
+					if ( topItem.type === "stack" && topItem._header && !topItem._header.isDropArea && topItem.contentItems.length > 0 ) {
+						parentItem = this._layoutManager.createContentItem({type: "row"});
+						this._layoutManager.root.replaceChild(topItem, parentItem);
+						parentItem.addChild(topItem);
+					} else {
+						parentItem = topItem;
+					}
 				} else {
 					parentItem = this._layoutManager.root;
 				}
@@ -104,7 +116,7 @@ lm.utils.copy( lm.controls.BrowserPopout.prototype, {
 			}
 		}
 
-		parentItem.addChild( childConfig, this._indexInParent );
+		parentItem.addChild( childConfig, index );
 		this.close();
 	},
 

--- a/src/js/items/RowOrColumn.js
+++ b/src/js/items/RowOrColumn.js
@@ -40,6 +40,8 @@ lm.utils.copy( lm.items.RowOrColumn.prototype, {
 
 		if( index === undefined ) {
 			index = this.contentItems.length;
+		} else if (index > this.contentItems.length) {
+			index = this.contentItems.length;
 		}
 
 		if( this.contentItems.length > 0 ) {

--- a/src/js/items/Stack.js
+++ b/src/js/items/Stack.js
@@ -6,6 +6,7 @@ lm.items.Stack = function( layoutManager, config, parent ) {
 	var cfg = layoutManager.config;
 	this._header = { // defaults' reconstruction from old configuration style
 		show: cfg.settings.hasHeaders === true && config.hasHeaders !== false,
+		isDropArea: cfg.settings.stackingEnabled === true && config.stackingEnabled !== false,
 		popout: cfg.settings.showPopoutIcon && cfg.labels.popout,
 		maximise: cfg.settings.showMaximiseIcon && cfg.labels.maximise,
 		close: cfg.settings.showCloseIcon && cfg.labels.close,
@@ -309,13 +310,15 @@ lm.utils.copy( lm.items.Stack.prototype, {
 		}
 
 		var getArea = lm.items.AbstractContentItem.prototype._$getArea,
-			headerArea = getArea.call( this, this.header.element ),
 			contentArea = getArea.call( this, this.childElementContainer ),
 			contentWidth = contentArea.x2 - contentArea.x1,
-			contentHeight = contentArea.y2 - contentArea.y1;
+			contentHeight = contentArea.y2 - contentArea.y1,
+			headerArea = null;
 
-		this._contentAreaDimensions = {
-			header: {
+		this._contentAreaDimensions = {};
+		if (this._header.isDropArea) {
+			headerArea = getArea.call( this, this.header.element );
+			this._contentAreaDimensions.header = {
 				hoverArea: {
 					x1: headerArea.x1,
 					y1: headerArea.y1,
@@ -328,8 +331,8 @@ lm.utils.copy( lm.items.Stack.prototype, {
 					x2: headerArea.x2,
 					y2: headerArea.y2
 				}
-			}
-		};
+			};
+		}
 
 		/**
 		 * If this Stack is a parent to rows, columns or other stacks only its


### PR DESCRIPTION
I think there's a need for the capability to disable stacking to be officially supported. My project needs to disable stacking globally and there were a few issues I ran into, particularly with popouts. The api and variable names will need some discussion, I'm sure, but this is what I have:

myLayout.settings.stackingEnabled = false (defaults to true)
responsiveMode is presumably not wanted, so it is treated as if it was set to "off"
when returning popouts to the layout, it will never stack it on a root stack item (instead it will create a row for both children).
Header drop zones won't ever be returned when drop zone areas are calculated.

stack.config.stackingEnabled = false (defaults to myLayout.stackingEnabled)
responsiveMode isn't affected (although it should perhaps check to make sure it doesn't stack anything on a stack with stacking disabled)
When returning popouts to the layout, it will check the stack's config before stacking anything on it.
Header drop zones will be returned for the stack unless the stack's config says to disable stacking.

I also included some bug fixes for returning popouts to the layout in my second commit. I found some issues with invalid indexes being passed into the addChild call.