### PR TITLE
setActiveContentItem only if changed

### DIFF
--- a/src/js/controls/Header.js
+++ b/src/js/controls/Header.js
@@ -112,6 +112,8 @@ lm.utils.copy( lm.controls.Header.prototype, {
 	setActiveContentItem: function( contentItem ) {
 		var i, j, isActive, activeTab;
 
+		if (this.activeContentItem === contentItem) return;
+		
 		for( i = 0; i < this.tabs.length; i++ ) {
 			isActive = this.tabs[ i ].contentItem === contentItem;
 			this.tabs[ i ].setActive( isActive );

--- a/src/js/controls/Tab.js
+++ b/src/js/controls/Tab.js
@@ -148,12 +148,9 @@ lm.utils.copy( lm.controls.Tab.prototype, {
 	_onTabClick: function( event ) {
 		// left mouse button or tap
 		if( event.button === 0 || event.type === 'touchstart' ) {
-			var activeContentItem = this.header.parent.getActiveContentItem();
-			if( this.contentItem !== activeContentItem ) {
-				this.header.parent.setActiveContentItem( this.contentItem );
-			}
-
-			// middle mouse button
+			this.header.parent.setActiveContentItem( this.contentItem );
+			
+		// middle mouse button
 		} else if( event.button === 1 && this.contentItem.config.isClosable ) {
 			this._onCloseClick( event );
 		}

--- a/src/js/items/Stack.js
+++ b/src/js/items/Stack.js
@@ -92,6 +92,7 @@ lm.utils.copy( lm.items.Stack.prototype, {
 	},
 
 	setActiveContentItem: function( contentItem ) {
+		if (this._activeContentItem === contentItem) return;
 		if( lm.utils.indexOf( contentItem, this.contentItems ) === -1 ) {
 			throw new Error( 'contentItem is not a child of this stack' );
 		}


### PR DESCRIPTION
Improve performance by moving the check to see if the item has changed from Tab to Stack and Header.