### PR TITLE
Cleanup jQuery event shorthand methods

### DIFF
--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -1201,7 +1201,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 	 */
 	_bindEvents: function() {
 		if( this._isFullPage ) {
-			$( window ).resize( this._resizeFunction );
+			$( window ).on( 'resize', this._resizeFunction );
 		}
 		$( window ).on( 'unload beforeunload', this._unloadFunction );
 	},
@@ -1275,7 +1275,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 			'<div class="lm_bg"></div>' +
 			'</div>' );
 
-		popInButton.click( lm.utils.fnBind( function() {
+		popInButton.on( 'click', lm.utils.fnBind( function() {
 			this.emit( 'popIn' );
 		}, this ) );
 
@@ -1996,7 +1996,7 @@ lm.utils.copy( lm.controls.BrowserPopout.prototype, {
 	 */
 	_positionWindow: function() {
 		this._popoutWindow.moveTo( this._dimensions.left, this._dimensions.top );
-		this._popoutWindow.focus();
+		this._popoutWindow.trigger( 'focus' );
 	},
 
 	/**
@@ -2347,7 +2347,7 @@ lm.controls.Header = function( layoutManager, parent ) {
 	this.closeButton = null;
 	this.tabDropdownButton = null;
 	this.hideAdditionalTabsDropdown = lm.utils.fnBind(this._hideAdditionalTabsDropdown, this);
-	$( document ).mouseup(this.hideAdditionalTabsDropdown);
+	$( document ).on( 'mouseup', this.hideAdditionalTabsDropdown );
 
 	this._lastVisibleTabIndex = -1;
 	this._tabControlOffset = this.layoutManager.config.settings.tabControlOffset;

--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -1996,7 +1996,7 @@ lm.utils.copy( lm.controls.BrowserPopout.prototype, {
 	 */
 	_positionWindow: function() {
 		this._popoutWindow.moveTo( this._dimensions.left, this._dimensions.top );
-		this._popoutWindow.trigger( 'focus' );
+		this._popoutWindow.focus();
 	},
 
 	/**

--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -760,7 +760,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 	 */
 	_bindEvents: function() {
 		if( this._isFullPage ) {
-			$( window ).resize( this._resizeFunction );
+			$( window ).on( 'resize', this._resizeFunction );
 		}
 		$( window ).on( 'unload beforeunload', this._unloadFunction );
 	},
@@ -834,7 +834,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 			'<div class="lm_bg"></div>' +
 			'</div>' );
 
-		popInButton.click( lm.utils.fnBind( function() {
+		popInButton.on( 'click', lm.utils.fnBind( function() {
 			this.emit( 'popIn' );
 		}, this ) );
 

--- a/src/js/controls/BrowserPopout.js
+++ b/src/js/controls/BrowserPopout.js
@@ -232,7 +232,7 @@ lm.utils.copy( lm.controls.BrowserPopout.prototype, {
 	 */
 	_positionWindow: function() {
 		this._popoutWindow.moveTo( this._dimensions.left, this._dimensions.top );
-		this._popoutWindow.trigger( 'focus' );
+		this._popoutWindow.focus();
 	},
 
 	/**

--- a/src/js/controls/BrowserPopout.js
+++ b/src/js/controls/BrowserPopout.js
@@ -232,7 +232,7 @@ lm.utils.copy( lm.controls.BrowserPopout.prototype, {
 	 */
 	_positionWindow: function() {
 		this._popoutWindow.moveTo( this._dimensions.left, this._dimensions.top );
-		this._popoutWindow.focus();
+		this._popoutWindow.trigger( 'focus' );
 	},
 
 	/**

--- a/src/js/controls/Header.js
+++ b/src/js/controls/Header.js
@@ -27,7 +27,7 @@ lm.controls.Header = function( layoutManager, parent ) {
 	this.dockButton = null;
 	this.tabDropdownButton = null;
 	this.hideAdditionalTabsDropdown = lm.utils.fnBind(this._hideAdditionalTabsDropdown, this);
-	$( document ).mouseup(this.hideAdditionalTabsDropdown);
+	$( document ).on( 'mouseup', this.hideAdditionalTabsDropdown );
 
 	this._lastVisibleTabIndex = -1;
 	this._tabControlOffset = this.layoutManager.config.settings.tabControlOffset;


### PR DESCRIPTION
Removed usage of jQuery event shorthand method since it is marked as deprecated in 3.3.1 onward and will be removed from slim builds eventually