### PR TITLE
Fix for #205

### DIFF
--- a/src/js/items/AbstractContentItem.js
+++ b/src/js/items/AbstractContentItem.js
@@ -183,6 +183,10 @@ lm.utils.copy( lm.items.AbstractContentItem.prototype, {
 
 		parentNode.replaceChild( newChild.element[ 0 ], oldChild.element[ 0 ] );
 
+		if( this._activeContentItem === oldChild ) {
+			this._activeContentItem = newChild;
+		}
+
 		/*
 		 * Optionally destroy the old content item
 		 */


### PR DESCRIPTION
Properly update the active item when replacing the currently active item in a stack. This prevents the issue I detailed in #205 (there's a detailed breakdown of the bug there as well for anyone interested).