### PR TITLE
Fix for #436

### DIFF
--- a/webpack.config.dev.babel.js
+++ b/webpack.config.dev.babel.js
@@ -328,8 +328,6 @@ module.exports = (env) => {
         support_library: process.env.JQUERY ? path.join('lib', 'jquery.js'): path.join('lib', 'zepto.js')
       }),
 
-      new MinifyPlugin,
-
       new BrowserSyncPlugin({
         files: "dist/**/*.*",
         hostname: "localhost",
@@ -341,6 +339,10 @@ module.exports = (env) => {
         reloadOnRestart: true,
       }),
 
-    ] : [])),
+    ] : [
+    
+      new MinifyPlugin,
+
+    ])),
   }
 }


### PR DESCRIPTION
Quick fix for the bug introduced by my commit a4e84ec5 which had fixed the "two touches bug" on drag.
Sorry for the inconvenience.

Note: I tried to make the dragged tab disappear from its original spot, but there's just no way to make it work. Perhaps I'll figure it out later.
