### PR TITLE
Implement popInOnClose option

### DIFF
--- a/src/js_es6/LayoutManager.js
+++ b/src/js_es6/LayoutManager.js
@@ -49,7 +49,7 @@ export default class LayoutManager extends EventEmitter {
             errorMsg += 'your paths when using RequireJS/AMD';
             throw new Error(errorMsg);
         }
-        
+
         super();
 
         this.isInitialised = false;
@@ -428,7 +428,7 @@ export default class LayoutManager extends EventEmitter {
      * @param    {[String]} parentId the id of the element this item will be appended to
      *                             when popIn is called
      * @param    {[Number]} indexInParent The position of this item within its parent element
-     
+
      * @returns {BrowserPopout}
      */
     createPopout(configOrContentItem, dimensions, parentId, indexInParent) {
@@ -867,23 +867,24 @@ export default class LayoutManager extends EventEmitter {
      * @returns {void}
      */
     _adjustToWindowMode() {
-        var popInButton = $('<div class="lm_popin" title="' + this.config.labels.popin + '">' +
-            '<div class="lm_icon"></div>' +
-            '<div class="lm_bg"></div>' +
-            '</div>');
-
-        popInButton.click(fnBind(function() {
-            this.emit('popIn');
-        }, this));
-
         document.title = stripTags(this.config.content[0].title);
 
         $('head').append($('body link, body style, template, .gl_keep'));
 
-        this.container = $('body')
-            .html('')
-            .css('visibility', 'visible')
-            .append(popInButton);
+        this.container = $('body').css('visibility', 'visible')
+
+        // Create and append the popIn button only iff config.settings.popInOnClose is not set or set to false
+        if (!this.config.settings.popInOnClose) {
+          var popInButton = $('<div class="lm_popin" title="' + this.config.labels.popin + '">' +
+              '<div class="lm_icon"></div>' +
+              '<div class="lm_bg"></div>' +
+              '</div>');
+
+          popInButton.click(fnBind(function() {
+              this.emit('popIn');
+          }, this));
+          this.container.append(popInButton);
+        }
 
         /*
          * This seems a bit pointless, but actually causes a reflow/re-evaluation getting around

--- a/src/js_es6/config/defaultConfig.js
+++ b/src/js_es6/config/defaultConfig.js
@@ -9,6 +9,7 @@ const defaultConfig = {
         blockedPopoutsThrowError: true,
         closePopoutsOnUnload: true,
         showPopoutIcon: true,
+        popInOnClose: false,
         showMaximiseIcon: true,
         showCloseIcon: true,
         responsiveMode: 'onload', // Can be onload, always, or none.

--- a/src/js_es6/controls/BrowserPopout.js
+++ b/src/js_es6/controls/BrowserPopout.js
@@ -27,7 +27,7 @@ export default class BrowserPopout extends EventEmitter {
     constructor(config, dimensions, parentId, indexInParent, layoutManager) {
 
         super();
-        
+
         this.isInitialised = false;
 
         this._config = config;
@@ -115,7 +115,11 @@ export default class BrowserPopout extends EventEmitter {
         }
 
         parentItem.addChild(childConfig, this._indexInParent);
-        this.close();
+        if (this._layoutManager.config.settings.popInOnClose) {
+          this._onClose();
+        } else {
+          this.close();
+        }
     }
 
     /**
@@ -166,9 +170,15 @@ export default class BrowserPopout extends EventEmitter {
             }
         }
 
-        $(this._popoutWindow)
+        const $pw = $(this._popoutWindow)
             .on('load', fnBind(this._positionWindow, this))
-            .on('unload beforeunload', fnBind(this._onClose, this));
+
+        if (this._layoutManager.config.settings.popInOnClose) {
+          $pw.on('beforeunload', (ev) => this.popIn());
+        } else {
+          $pw.on('unload beforeunload', fnBind(this._onClose, this));
+        }
+
 
         /**
          * Polling the childwindow to find out if GoldenLayout has been initialised


### PR DESCRIPTION
This PR implements an additional option within the configuration to change the behavior of popout windows.

It introduces a new configuration option disabled by default and does not break any existing behavior.
When `config.settings.popInOnClose` is set to `true`, it won't append the `popIn` button but instead bind the `beforeunload` handler of the child window to `popIn`.

Please note that this PR is only implemented against the ES6 version.