### PR TITLE
Properly calculate root item areas

### DIFF
--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -608,14 +608,16 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 
 	_$createRootItemAreas: function() {
 		var areaSize = 50;
-		var sides = { y2: 0, x2: 0, y1: 'y2', x1: 'x2' };
+		var sides = { y2: 'y1', x2: 'x1', y1: 'y2', x1: 'x2' };
+		var rootarea = this.root._$getArea()
 		for( var side in sides ) {
 			var area = this.root._$getArea();
 			area.side = side;
-			if( sides [ side ] )
+			if( sides [ side ][1] == '2' )
 				area[ side ] = area[ sides [ side ] ] - areaSize;
-			else
-				area[ side ] = areaSize;
+			else {
+				area[ side ] = area[ sides [ side ] ] + areaSize;
+			}
 			area.surface = ( area.x2 - area.x1 ) * ( area.y2 - area.y1 );
 			this._itemAreas.push( area );
 		}

--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -609,7 +609,6 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 	_$createRootItemAreas: function() {
 		var areaSize = 50;
 		var sides = { y2: 'y1', x2: 'x1', y1: 'y2', x1: 'x2' };
-		var rootarea = this.root._$getArea()
 		for( var side in sides ) {
 			var area = this.root._$getArea();
 			area.side = side;

--- a/src/js_es6/LayoutManager.js
+++ b/src/js_es6/LayoutManager.js
@@ -650,10 +650,10 @@ export default class LayoutManager extends EventEmitter {
         for (var side in sides) {
             var area = this.root._$getArea();
             area.side = side;
-		    if( sides [ side ][1] === '2' )
+            if (sides[side][1] === '2' )
                 area[side] = area[sides[side]] - areaSize;
             else
-                area[ side ] = area[ sides [ side ] ] + areaSize;
+                area[side] = area[sides[side]] + areaSize;
             area.surface = (area.x2 - area.x1) * (area.y2 - area.y1);
             this._itemAreas.push(area);
         }

--- a/src/js_es6/LayoutManager.js
+++ b/src/js_es6/LayoutManager.js
@@ -642,18 +642,18 @@ export default class LayoutManager extends EventEmitter {
     _$createRootItemAreas() {
         var areaSize = 50;
         var sides = {
-            y2: 0,
-            x2: 0,
+            y2: 'y1',
+            x2: 'x1',
             y1: 'y2',
             x1: 'x2'
         };
         for (var side in sides) {
             var area = this.root._$getArea();
             area.side = side;
-            if (sides[side])
+		    if( sides [ side ][1] === '2' )
                 area[side] = area[sides[side]] - areaSize;
             else
-                area[side] = areaSize;
+                area[ side ] = area[ sides [ side ] ] + areaSize;
             area.surface = (area.x2 - area.x1) * (area.y2 - area.y1);
             this._itemAreas.push(area);
         }


### PR DESCRIPTION
Update layout manager to properly calculate root item areas when the layout origin is not (0,0). 

Currently if a dashboard is not positioned at or near 0,0 in the document, the left and top root drag areas do not work.  This fixes that by adding in the current x and y offset to the root areas when appropriate.