### PR TITLE
clear LayoutManager._maximisedItem when the maximised item is destroyed

### DIFF
--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -543,6 +543,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 			this._$minimiseItem( this._maximisedItem );
 		}
 		this._maximisedItem = contentItem;
+		contentItem.on( 'beforeItemDestroyed', this._$cleanupBeforeMaximisedItemDestroyed, this );
 		this._maximisedItem.addId( '__glMaximised' );
 		contentItem.element.addClass( 'lm_maximised' );
 		contentItem.element.after( this._maximisePlaceholder );
@@ -561,8 +562,16 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 		this._maximisePlaceholder.remove();
 		contentItem.parent.callDownwards( 'setSize' );
 		this._maximisedItem = null;
+		contentItem.off( 'beforeItemDestroyed', this._$cleanupBeforeMaximisedItemDestroyed, this );
 		contentItem.emit( 'minimised' );
 		this.emit( 'stateChanged' );
+	},
+
+	_$cleanupBeforeMaximisedItemDestroyed: function( contentItem ) {
+		if (this._maximisedItem === event.origin) {
+			this._maximisedItem.off( 'beforeItemDestroyed', this._$cleanupBeforeMaximisedItemDestroyed, this );
+			this._maximisedItem = null;
+		}
 	},
 
 	/**


### PR DESCRIPTION
`LayoutManager._maximisedItem` is not cleared when the maximised item is removed from the layout without minimizing it first. This pull request fixes it by listening for the `beforeItemDestroyed` event and clearing `LayoutManager._maximisedItem` if needed.

Steps to reproduce the original bug:

1. Install a handler on the `stateChanged` event of the layout and dump the value of `_maximisedItem` from the handler.

2. Maximise an item. Note that the `stateChanged` handler dumps the item correctly as it is now maximised.

3. Remove the item from the layout with the X button of its parent stack or with its own X button, then observe that the `stateChanged` handler still dumps the original maximised item even though it was removed.