### PR TITLE
Fix destroy

### DIFF
--- a/src/js/items/AbstractContentItem.js
+++ b/src/js/items/AbstractContentItem.js
@@ -108,6 +108,7 @@ lm.utils.copy( lm.items.AbstractContentItem.prototype, {
 		 */
 		if( keepChild !== true ) {
 			this.contentItems[ index ]._$destroy();
+			this.contentItems[ index ].callDownwards('_$destroy', [], true, true);
 		}
 
 		/**
@@ -452,7 +453,6 @@ lm.utils.copy( lm.items.AbstractContentItem.prototype, {
 	 */
 	_$destroy: function() {
 		this.emitBubblingEvent( 'beforeItemDestroyed' );
-		this.callDownwards( '_$destroy', [], true, true );
 		this.element.remove();
 		this.emitBubblingEvent( 'itemDestroyed' );
 	},

--- a/src/js/items/AbstractContentItem.js
+++ b/src/js/items/AbstractContentItem.js
@@ -104,7 +104,8 @@ lm.utils.copy( lm.items.AbstractContentItem.prototype, {
 		}
 
 		/**
-		 * Call ._$destroy on the content item. This also calls ._$destroy on all its children
+		 * Call ._$destroy on the content item. 
+		 * Then use 'callDownwards' to destroy any children
 		 */
 		if( keepChild !== true ) {
 			this.contentItems[ index ]._$destroy();

--- a/src/js_es6/items/AbstractContentItem.js
+++ b/src/js_es6/items/AbstractContentItem.js
@@ -121,10 +121,12 @@ export default class AbstractContentItem extends EventEmitter {
         }
 
         /**
-         * Call ._$destroy on the content item. This also calls ._$destroy on all its children
-         */
+		 * Call ._$destroy on the content item. 
+		 * Then use 'callDownwards' to destroy any children
+		 */
         if (keepChild !== true) {
-            this.contentItems[index]._$destroy();
+			this.contentItems[index]._$destroy();
+			this.contentItems[index].callDownwards('_$destroy', [], true, true);
         }
 
         /**
@@ -494,7 +496,6 @@ export default class AbstractContentItem extends EventEmitter {
      */
     _$destroy() {
         this.emitBubblingEvent('beforeItemDestroyed');
-        this.callDownwards('_$destroy', [], true, true);
         this.element.remove();
         this.emitBubblingEvent('itemDestroyed');
     }


### PR DESCRIPTION
This is a proposed fix for issue #484.  It removes 'callDownwards' from AbstractContentItem._$destroy and adds it to removeChild instead.

A back-ported version of this fix based on 1.5.9 (last release) shows the fix in this codepen:
https://codepen.io/jvanderberg/pen/XOZpZq.

The 'clear' button deletes the layout very quickly, and also, at least on first glance, drag and drop, delete, and such work without regression, but I am very likely missing something.