### PR TITLE
Remove the postinstall step that deleted *.info files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "build_es6z_watch": "npm run clean && cross-env STYLES=scss ES6=true ZEPTO=true webpack --progress --env.build --env.build_watch --config webpack.config.dev.babel.js",
     "clean": "npm-run-all clean:*",
     "clean:dist": "del-cli dist",
-    "postinstall": "del-cli node_modules/**/*.info",
     "lint:autofix": "stylelint src/scss/**/*.scss --fix && eslint src/js --fix",
     "lint_es6:autofix": "stylelint src/scss/**/*.scss --fix && eslint src/js_es6 --fix",
     "prestart": "npm-run-all --parallel clean",


### PR DESCRIPTION
I tried to track down why this was initially implemented, and it appears to have first been included when changing to WebPack with commit: 334c94da502395b224babcf89bb6cb8c27c5f445

Ran the various npm start/build commands to make sure nothing was broken:
`npm run start`
`npm run build`
`npm run start_es6j`
`npm run build_es6j`
`npm run start_es6z`
`npm run build_es6z`