### PR TITLE
Fixing Incorrect activeItemIndex after removing siblings

### DIFF
--- a/src/js/items/Stack.js
+++ b/src/js/items/Stack.js
@@ -136,6 +136,11 @@ lm.utils.copy( lm.items.Stack.prototype, {
 			} else {
 				this._activeContentItem = null;
 			}
+		} else if (this.config.activeItemIndex >= this.contentItems.length) {
+			if (this.contentItems.length > 0) {
+				var activeIndex = lm.utils.indexOf( this.getActiveContentItem(), this.contentItems );
+				this.config.activeItemIndex = Math.max(activeIndex, 0);
+			}
 		}
 
 		this._$validateClosability();


### PR DESCRIPTION
Fixing this issue: https://github.com/golden-layout/golden-layout/issues/418