### PR TITLE
Infinit loop when closing popup window

### DIFF
--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -741,8 +741,8 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 		}
 
 		if( this.openPopouts.length !== openPopouts.length ) {
-			this.emit( 'stateChanged' );
 			this.openPopouts = openPopouts;
+			this.emit( 'stateChanged' );
 		}
 
 	},


### PR DESCRIPTION
When stateChanged is triggered before variable change it cause infinit loop, after closing popup window