### PR TITLE
Fixed replaceChild to update the activeContentItem

### DIFF
--- a/src/js/items/AbstractContentItem.js
+++ b/src/js/items/AbstractContentItem.js
@@ -211,6 +211,11 @@ lm.utils.copy( lm.items.AbstractContentItem.prototype, {
 			newChild._$init();
 		}
 
+		// Update the activeContentItem if equal to the oldChild without making a call to setActiveContentItem, which attempts to hide the current activeContentItem
+		if(this._activeContentItem === oldChild) {
+			this.updateActiveContentItem(newChild);
+		}
+
 		this.callDownwards( 'setSize' );
 	},
 

--- a/src/js/items/Stack.js
+++ b/src/js/items/Stack.js
@@ -95,6 +95,15 @@ lm.utils.copy( lm.items.Stack.prototype, {
 		}
 	},
 
+	updateActiveContentItem: function( contentItem ) {
+		if( lm.utils.indexOf( contentItem, this.contentItems ) === -1 ) {
+			throw new Error( 'contentItem is not a child of this stack' );
+		}
+
+		this._activeContentItem = contentItem;
+
+	},
+
 	setActiveContentItem: function( contentItem ) {
 		if (this._activeContentItem === contentItem) return;
 		if( lm.utils.indexOf( contentItem, this.contentItems ) === -1 ) {


### PR DESCRIPTION
### Demo:
https://codepen.io/jay8888/pen/NZojqb?editors=1010

1. Go to the codepen and click "Add Component" and a layout will appear as a sibling of the container.

2. Next, remove the bottom component and click "Add Component" again.

- Notice how 'Content Child 1' will appear in the tab but the correct content does not show (content still shows the same as the previous tab).
- The expected outcome can be seen if we repeat the steps from the beginning clicking "Add Component" but instead of removing the bottom component, either remove the left or right component or do not remove anything at all, and then proceed to click "Add Component" again to see the correct layout.
- **Note:** It is possible to wrap the original config in an additional column and solve the issue but this seems unnecessary and should be solved within the framework.

### Why does this happen?
- The first time we press "Add Component", the activeContentItem is set to the RowOrColumn that contains our Left, Right, and Bottom Components. However, in the removal of the Bottom Component, a call is made to replaceChild to remove the existing RowOrColumn and to update the tree hierarchy. 
- If the RowOrColumn we are replacing is also the activeContentItem, we need to update the activeContentItem to newChild which has the proper contentItems. If we do not update activeContentItem, after removing the Bottom Component and clicking "Add Component" again, setActiveContentItem attempts to hide the activeContentItem which happens to be the removed RowOrColumn that does not have the proper contentItems, and does not reflect the current tree hierarchy because of the calls to replaceChild.

### Solution:
 - Check to see if the _activeContentItem of the Stack is the oldNode, if it is then we update it to the newNode. We do not want to make a call to setActiveContentItem to update activeContentItem as this will attempt to hide the current activeContentItem, we simply want to update the reference of the activeContentItem to the newNode.
