### PR TITLE
#572 Add registerUnknownComponent, registerUnknownReactComponent

### DIFF
--- a/src/js_es6/LayoutManager.js
+++ b/src/js_es6/LayoutManager.js
@@ -153,6 +153,62 @@ export default class LayoutManager extends EventEmitter {
         this._components[name] = constructor;
     }
 
+     /**
+     * Register an unknown component with the layout manager. If a configuration node
+     * of unknown type is reached it will look up the provided unknown component
+     * and create that component instead
+     *
+     *  {
+     *    type: "component",
+     *    componentName: "EquityNewsFeed",
+     *    componentState: { "feedTopic": "us-bluechips" }
+     *  }
+     *
+     * @public
+     * @param   {Function} constructor
+     *
+     * @returns {void}
+     */
+    registerUnknownComponent(constructor) {
+        if (typeof constructor !== 'function') {
+            throw new Error('Please register a constructor function');
+        }
+
+        if (this._unknownComponent !== undefined) {
+            throw new Error('An unknown component is already registered');
+        }
+
+        this._unknownComponent = constructor;
+    }   
+
+     /**
+     * Register an unknown react component with the layout manager. If a configuration node
+     * of unknown type that is react is reached it will look up the provided unknown component
+     * and create that component instead
+     *
+     *  {
+     *    type: "component",
+     *    componentName: "EquityNewsFeed",
+     *    componentState: { "feedTopic": "us-bluechips" }
+     *  }
+     *
+     * @public
+     * @param   {Function} constructor
+     *
+     * @returns {void}
+     */
+    registerUnknownReactComponent(constructor) {
+        if (typeof constructor !== 'function') {
+            throw new Error('Please register a constructor function');
+        }
+
+        if (this._unknownReactComponent !== undefined) {
+            throw new Error('An unknown react component is already registered');
+        }
+
+        this._unknownReactComponent = constructor;
+    }   
+
     /**
      * Creates a layout configuration object based on the the current state
      *
@@ -227,7 +283,8 @@ export default class LayoutManager extends EventEmitter {
     }
 
     /**
-     * Returns a previously registered component
+     * Returns a previously registered component.  If no component is found to be registered 
+     * and an unknown component has been registered, that will be used instead.
      *
      * @public
      * @param   {String} name The name used
@@ -235,11 +292,28 @@ export default class LayoutManager extends EventEmitter {
      * @returns {Function}
      */
     getComponent(name) {
-        if (this._components[name] === undefined) {
+        if (this._components[name] === undefined && this._unknownComponent === undefined) {
             throw new ConfigurationError('Unknown component "' + name + '"');
         }
 
-        return this._components[name];
+        return this._components[name] || this._unknownComponent;
+    }
+
+    /**
+     * Returns a previously registered react component.  If no component is found to be registered 
+     * and an unknown react component has been registered, that will be used instead.
+     *
+     * @public
+     * @param   {String} name The name used
+     *
+     * @returns {Function}
+     */
+    getReactComponent(name) {
+        if (this._components[name] === undefined && this._unknownReactComponent === undefined) {
+            throw new ConfigurationError('Unknown react component "' + name + '"');
+        }
+
+        return this._components[name] || this._unknownReactComponent;
     }
 
     /**

--- a/src/js_es6/utils/ReactComponentHandler.js
+++ b/src/js_es6/utils/ReactComponentHandler.js
@@ -93,7 +93,7 @@ export default class ReactComponentHandler {
             throw new Error('No react component name. type: react-component needs a field `component`');
         }
 
-        reactClass = this._container.layoutManager.getComponent(componentName);
+        reactClass = this._container.layoutManager.getReactComponent(componentName);
 
         if (!reactClass) {
             throw new Error('React component "' + componentName + '" not found. ' +


### PR DESCRIPTION
 - These allow users of the library to define fallback components in either case if they so desire.

See #572 for details on why.

I tested this with the project I'm working on, so here's an example of what it ends up looking like.

<img width="1327" alt="Screen Shot 2020-03-27 at 7 35 04 PM" src="https://user-images.githubusercontent.com/11984853/77812932-1b93d300-7062-11ea-853a-4810cd3f3f7e.png">

Not even sure if others are interested in this yet, so mostly putting this up for people to have an idea of what I mean.

The way I added it in is fairly simple for now, I'm open to changing it to whatever style people would prefer (passing booleans into methods rather than separate methods, 🤷‍♂ whatever).

In that screenshot, the titles shown are whatever the missing component title's name actually would be.  The content is a whatever the user of the library passes in to represent unknown components.  In the example, I passed in a component that just renders unknown component or unknown react component.
