### PR TITLE
Adds registerComponentFunction, fixes minor React 16 issue

### DIFF
--- a/src/js_es6/items/Component.js
+++ b/src/js_es6/items/Component.js
@@ -1,6 +1,6 @@
 import AbstractContentItem from '../items/AbstractContentItem'
 import ItemContainer from '../container/ItemContainer'
-
+import ReactComponentHandler from '../utils/ReactComponentHandler'
 
 /**
  * @param {[type]} layoutManager [description]
@@ -14,7 +14,7 @@ export default class Component extends AbstractContentItem {
 
         super(layoutManager, config, parent);
 
-        var ComponentConstructor = layoutManager.getComponent(this.config.componentName),
+        var ComponentConstructor = layoutManager.isReactConfig(config) ? ReactComponentHandler : layoutManager.getComponent(config),
             componentConfig = $.extend(true, {}, this.config.componentState || {});
 
         componentConfig.componentName = this.config.componentName;

--- a/src/js_es6/utils/ReactComponentHandler.js
+++ b/src/js_es6/utils/ReactComponentHandler.js
@@ -36,7 +36,7 @@ export default class ReactComponentHandler {
     }
 
     /**
-     * Fired by react when the component is created.
+     * Fired by react when the component is created.  Also fired upon destruction (where component is null).
      * <p>
      * Note: This callback is used instead of the return from `ReactDOM.render` because
      *	   of https://github.com/facebook/react/issues/10309.
@@ -47,11 +47,13 @@ export default class ReactComponentHandler {
      * @returns {void}
      */
     _gotReactComponent(component) {
-        this._reactComponent = component;
-        this._originalComponentWillUpdate = this._reactComponent.componentWillUpdate || function() {};
-        this._reactComponent.componentWillUpdate = this._onUpdate.bind( this );
-        if( this._container.getState() ) {
-            this._reactComponent.setState( this._container.getState() );
+        if (component !== null) {
+            this._reactComponent = component;
+            this._originalComponentWillUpdate = this._reactComponent.componentWillUpdate || function() {};
+            this._reactComponent.componentWillUpdate = this._onUpdate.bind( this );
+            if( this._container.getState() ) {
+                this._reactComponent.setState( this._container.getState() );
+            }
         }
     }
     
@@ -93,7 +95,7 @@ export default class ReactComponentHandler {
             throw new Error('No react component name. type: react-component needs a field `component`');
         }
 
-        reactClass = this._container.layoutManager.getComponent(componentName);
+        reactClass = this._container.layoutManager.getComponent(this._container._config);
 
         if (!reactClass) {
             throw new Error('React component "' + componentName + '" not found. ' +


### PR DESCRIPTION
#572 
 - Adds a registerComponentFunction.  This takes in a callback that allows users of the library to implement more custom functionality around what gets used as a component.  To allow maximum flexibility, the entire config is passed rather than only the name.
 - Adds a method called isReactConfig.  This will be helpful both internally and externally, since if something is react it typically needs to be handled differently.
 - Adds a method called getComponentNameFromConfig.  This is helpful because where to find the name in the config depends on whether or not it's a react component.
 - Updates nextNode to be an arrow function, so the binding of this is works for the inner function call as expected.
 - Updates getComponent to first see if a named component is registered, then fallback to a component function if one exists, and finally to through an error if all of those come up empty (component function can return undefined if it really doesn't want to handle a specific case!).  It's fairly flexible now.
 - Moves 'lm-react-component' into a const.
 - Removes the ReactComponentHandler from being stored in the component list, and instead imports it into Component.js directly (this is the only usage I could find).
 - Updates _gotReactComponent to work nicely with React 16 and higher.  While this function used to only be called on creation, it's also called on destruction now.  The destruction passes null for the component param, so we key off this to avoid doing anything on that call.