### PR TITLE
Unify dist structure for upgrade compatibiliy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 typings
 .idea
 .vscode
+*.tgz
 npm-debug.log
 /dist
 /doc

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -195,7 +195,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
      */
-    "untrimmedFilePath": "<projectFolder>/dist/golden-layout/<unscopedPackageName>-untrimmed.d.ts",
+    "untrimmedFilePath": "<projectFolder>/dist/types/<unscopedPackageName>-untrimmed.d.ts",
 
     /**
      * Specifies the output path for a .d.ts rollup file to be generated with trimming for a "beta" release.
@@ -221,7 +221,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: ""
      */
-    "publicTrimmedFilePath": "<projectFolder>/dist/golden-layout/index.d.ts"
+    "publicTrimmedFilePath": "<projectFolder>/dist/types/index.d.ts"
 
     /**
      * When a declaration is trimmed, by default it will be replaced by a code comment such as

--- a/apitest/app.ts
+++ b/apitest/app.ts
@@ -1,4 +1,4 @@
-import { ComponentItemConfig, ContentItem, EventEmitter, GoldenLayout, LayoutConfig, ResolvedLayoutConfig, Stack } from "../dist/golden-layout";
+import { ComponentItemConfig, ContentItem, EventEmitter, GoldenLayout, LayoutConfig, ResolvedLayoutConfig, Stack } from '..';
 import { BooleanComponent } from './boolean-component';
 import { ColorComponent } from './color-component';
 import { Layout, prefinedLayouts } from './predefined-layouts';

--- a/apitest/boolean-component.ts
+++ b/apitest/boolean-component.ts
@@ -1,4 +1,4 @@
-import { ComponentContainer, JsonValue } from '../dist/golden-layout';
+import { ComponentContainer, JsonValue } from '..';
 
 export class BooleanComponent {
     static readonly typeName = 'boolean';

--- a/apitest/color-component.ts
+++ b/apitest/color-component.ts
@@ -1,4 +1,4 @@
-import { ComponentContainer, JsonValue } from '../dist/golden-layout';
+import { ComponentContainer, JsonValue } from '..';
 
 export class ColorComponent {
     static readonly typeName = 'color';

--- a/apitest/golden-layout.less
+++ b/apitest/golden-layout.less
@@ -1,2 +1,2 @@
-@import '../dist/golden-layout/less/goldenlayout-base.less';
-@import '../dist/golden-layout/less/themes/goldenlayout-dark-theme.less';
+@import '../dist/less/goldenlayout-base.less';
+@import '../dist/less/themes/goldenlayout-dark-theme.less';

--- a/apitest/predefined-layouts.ts
+++ b/apitest/predefined-layouts.ts
@@ -1,4 +1,4 @@
-import { ComponentItemConfig, ItemType, LayoutConfig } from '../dist/golden-layout';
+import { ComponentItemConfig, ItemType, LayoutConfig } from '..';
 import { BooleanComponent } from './boolean-component';
 import { ColorComponent } from './color-component';
 import { TextComponent } from './text-component';

--- a/apitest/text-component.ts
+++ b/apitest/text-component.ts
@@ -1,4 +1,4 @@
-import { ComponentContainer, JsonValue } from '../dist/golden-layout';
+import { ComponentContainer, JsonValue } from '..';
 
 export class TextComponent {
     private static readonly undefinedTextValue = '<undefined>';

--- a/apitest/tsconfig.json
+++ b/apitest/tsconfig.json
@@ -16,6 +16,6 @@
 	   "strictPropertyInitialization": true,
 	   "noImplicitAny": true,
 	   "downlevelIteration": true,
-	   "baseUrl": "./",
+       "baseUrl": "./",
 	},
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-layout",
-  "version": "2.0.0-beta.22",
+  "version": "2.0.0",
   "description": "A multi-screen javascript Layout manager",
   "keywords": [
     "docking",
@@ -16,9 +16,12 @@
   },
   "license": "MIT",
   "author": "Golden Layout community",
-  "main": "dist/cjs/golden-layout.js",
-  "module": "dist/golden-layout/index.js",
-  "typings": "dist/golden-layout/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "typings": "dist/types/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
   "sideEffects": false,
   "scripts": {
     "build:module": "tsc -p tsconfig.module.json",

--- a/scripts/css.js
+++ b/scripts/css.js
@@ -23,8 +23,8 @@ const ensureFolder = (dir) => {
 // Must be called for every .less file in src folder.
 const buildFile = async (filePath) => {
     console.log(`[INFO] Processing file: ${filePath}`);
-    const outputPath = filePath.replace('less', 'css').replace('src', 'dist/golden-layout').replace('.less', '.css');
-    const lessRawOutputFile = filePath.replace('src', 'dist/golden-layout');
+    const outputPath = filePath.replace('less', 'css').replace('src', 'dist').replace('.less', '.css');
+    const lessRawOutputFile = filePath.replace('src', 'dist');
     console.log(`[INFO] ${filePath} => render => ${outputPath}`);
     console.log(`[INFO] ${filePath} => copy => ${lessRawOutputFile}`);
 
@@ -44,20 +44,19 @@ console.log('[INFO] Creating directories');
 
 // We do not have mkdir -p without an extra dependency.
 ensureFolder('./dist');
-ensureFolder('./dist/golden-layout');
-ensureFolder('./dist/golden-layout/css');
-ensureFolder('./dist/golden-layout/less');
-ensureFolder('./dist/golden-layout/scss');
-ensureFolder('./dist/golden-layout/css/themes');
-ensureFolder('./dist/golden-layout/less/themes');
-ensureFolder('./dist/golden-layout/scss/themes');
-ensureFolder('./dist/golden-layout/img');
+ensureFolder('./dist/css');
+ensureFolder('./dist/less');
+ensureFolder('./dist/scss');
+ensureFolder('./dist/css/themes');
+ensureFolder('./dist/less/themes');
+ensureFolder('./dist/scss/themes');
+ensureFolder('./dist/img');
 
 
 // Build base.less file
 buildFile('./src/less/goldenlayout-base.less');
 // Copy the base scss file
-fs.copyFileSync('./src/scss/goldenlayout-base.scss', './dist/golden-layout/scss/goldenlayout-base.scss');
+fs.copyFileSync('./src/scss/goldenlayout-base.scss', './dist/scss/goldenlayout-base.scss');
 
 // Build every less theme
 fs.readdirSync('./src/less/themes').forEach(file => {
@@ -67,7 +66,7 @@ fs.readdirSync('./src/less/themes').forEach(file => {
 // Copy SCSS themes to dist
 fs.readdirSync('./src/scss/themes').forEach(file => {
     const srcPath = path.join('./src/scss/themes', file);
-    const dstPath = path.join('./dist/golden-layout/scss/themes', file);
+    const dstPath = path.join('./dist/scss/themes', file);
     console.log(`[INFO] ${srcPath} => copy => ${dstPath}`);
     fs.copyFileSync(srcPath, dstPath);
 });
@@ -75,7 +74,7 @@ fs.readdirSync('./src/scss/themes').forEach(file => {
 // Copy Images to dist
 fs.readdirSync('./src/img').forEach(file => {
     const srcPath = path.join('./src/img', file);
-    const dstPath = path.join('./dist/golden-layout/img', file);
+    const dstPath = path.join('./dist/img', file);
     console.log(`[INFO] ${srcPath} => copy => ${dstPath}`);
     fs.copyFileSync(srcPath, dstPath);
 });

--- a/tsconfig.module.api.json
+++ b/tsconfig.module.api.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.module.json",
     "compilerOptions": {
-        "outDir": "dist/golden-layout",
+        "outDir": "dist/esm",
         "stripInternal": false,
     },
 }

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-      "outDir": "dist/module",
+      "outDir": "dist/esm",
       "module": "es2020",
       "declaration": true,
       "declarationMap": true,


### PR DESCRIPTION
@pbklink 

I changed a bit in the configuration files:
- only ship dist/ in the resulting npm package
- ship the ts code:
  - dist/esm (ES Module version)
  - dist/cjs (CommonJS version)
  - dist/types (Typings from api-extractor)
  - dist/css (moved from dist/golden-layout/css for easier upgrade)
  - dist/(less|scss) (see above)
  - dist/img (see above)
  
This reduces the package size by not including any useless (to the end user) files.

@pbklink please take a look.