### PR TITLE
DragSource fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 <!-- ![Screenshot](https://cloud.githubusercontent.com/assets/512416/4584449/e6c154a0-4ffa-11e4-81a8-a7e5f8689dc5.PNG) -->
 
+## Version 2.0.1
+
+DragSources work in this release.
+
+Caution: **Breaking changes**
+1. `newComponent()` and `addComponent()` type functions in `LayoutManager`, `Stack` and `RowOrColumn` have a new `title` parameter.  This parameter is optional however it is not the last optional parameter.
+1. `LayoutManager.createDragSource()` has been renamed to `LayoutManager.newDragSource()`.  This is to make it more obvious that it is paired with `LayoutManager.removeDragSource()`
+1. `LayoutManager.newDragSource()` now only will create a ComponentItem. Its parameters have been changed to reflect that.
+1. TypeScript definition has been updated to remove many private declarations which should not have been included.
+
 ## Version 2
 
 Version 2.0 is now available from [NPM](https://www.npmjs.com/package/golden-layout). 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Caution: **Breaking changes**
 1. `LayoutManager.newDragSource()` now only will create a ComponentItem. Its parameters have been changed to reflect that.
 1. TypeScript definition has been updated to remove many private declarations which should not have been included.
 
+Note that `LayoutManager.newDragSource()` does not require `LayoutConfig.settings.constrainDragToContainer` to be set to false.
+
 ## Version 2
 
 Version 2.0 is now available from [NPM](https://www.npmjs.com/package/golden-layout). 

--- a/apitest/app.ts
+++ b/apitest/app.ts
@@ -1,4 +1,4 @@
-import { ComponentItemConfig, ContentItem, EventEmitter, GoldenLayout, LayoutConfig, ResolvedLayoutConfig, Stack } from '..';
+import { ComponentItemConfig, ContentItem, DragSource, EventEmitter, GoldenLayout, LayoutConfig, ResolvedLayoutConfig, Stack } from '..';
 import { BooleanComponent } from './boolean-component';
 import { ColorComponent } from './color-component';
 import { Layout, prefinedLayouts } from './predefined-layouts';
@@ -81,6 +81,15 @@ export class App {
         }
         this._addComponentButton = addComponentButton;
         this._addComponentButton.addEventListener('click', this._addComponentButtonClickListener, { passive: true });
+
+        const addComponentByDragButton = document.querySelector('#addComponentByDragButton') as HTMLButtonElement;
+        if (addComponentByDragButton === null) {
+            throw Error('Could not find addComponentByDragButton');
+        }
+        const addComponentDragSource = this._goldenLayout.newDragSource(addComponentByDragButton, () => this.getDragComponentTypeAndState());
+        if (addComponentDragSource === undefined) {
+            throw Error('addComponentDragSource undefined');
+        }
 
         const layoutSelect = document.querySelector('#layoutSelect') as HTMLSelectElement;
         if (layoutSelect === null) {
@@ -185,7 +194,7 @@ export class App {
         this._captureClickCount++;
         this._captureClickCountSpan.innerText = this._captureClickCount.toString();
     }
-    
+
     private handleRegisterExtraComponentTypesButtonClick() {
         this._goldenLayout.registerComponentConstructor(TextComponent.typeName, TextComponent);
         this._goldenLayout.registerComponentConstructor(BooleanComponent.typeName, BooleanComponent);
@@ -215,6 +224,11 @@ export class App {
     private handleAddComponentButtonClick() {
         const componentType = this._registeredComponentTypesForAddSelect.value;
         this._goldenLayout.addComponent(componentType);
+    }
+
+    private getDragComponentTypeAndState(): DragSource.ComponentItemConfig {
+        const componentType = this._registeredComponentTypesForAddSelect.value;
+        return { type: componentType };
     }
 
     private handleLoadLayoutButtonClick() {

--- a/apitest/index.html
+++ b/apitest/index.html
@@ -10,6 +10,7 @@
                 <button id="registerExtraComponentTypesButton">Register extra Component Types</button>
                 <section id="addComponentSection">
                     <select id="registeredComponentTypesForAddSelect" class="control"></select>
+                    <button id="addComponentByDragButton" class="control">D</button>
                     <button id="addComponentButton" class="control">Add Component</button>
                 </section>
                 <section id="predefinedLayoutsSection">

--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -6,6 +6,7 @@
 
 // @public (undocumented)
 export class ApiError extends ExternalError {
+    // @internal
     constructor(message: string);
 }
 
@@ -26,7 +27,10 @@ export interface AreaLinkedRect {
 // @public
 export class BrowserPopout extends EventEmitter {
     // @internal
-    constructor(_config: ResolvedPopoutLayoutConfig, _initialWindowSize: Rect, _layoutManager: LayoutManager);
+    constructor(
+    _config: ResolvedPopoutLayoutConfig,
+    _initialWindowSize: Rect,
+    _layoutManager: LayoutManager);
     // (undocumented)
     close(): void;
     // (undocumented)
@@ -41,7 +45,16 @@ export class BrowserPopout extends EventEmitter {
 // @public (undocumented)
 export class ComponentContainer extends EventEmitter {
     // @internal
-    constructor(_config: ResolvedComponentItemConfig, _parent: ComponentItem, _layoutManager: LayoutManager, _element: HTMLElement, _updateItemConfigEvent: ComponentContainer.UpdateItemConfigEventHandler, _showEvent: ComponentContainer.ShowEventHandler, _hideEvent: ComponentContainer.HideEventHandler, _focusEvent: ComponentContainer.FocusEventHandler, _blurEvent: ComponentContainer.BlurEventHandler);
+    constructor(
+    _config: ResolvedComponentItemConfig,
+    _parent: ComponentItem,
+    _layoutManager: LayoutManager,
+    _element: HTMLElement,
+    _updateItemConfigEvent: ComponentContainer.UpdateItemConfigEventHandler,
+    _showEvent: ComponentContainer.ShowEventHandler,
+    _hideEvent: ComponentContainer.HideEventHandler,
+    _focusEvent: ComponentContainer.FocusEventHandler,
+    _blurEvent: ComponentContainer.BlurEventHandler);
     blur(suppressEvent?: boolean): void;
     // @internal (undocumented)
     checkEmitHide(): void;
@@ -117,7 +130,8 @@ export namespace ComponentContainer {
 // @public (undocumented)
 export class ComponentItem extends ContentItem {
     // @internal
-    constructor(layoutManager: LayoutManager, config: ResolvedComponentItemConfig, _parentItem: ComponentParentableItem);
+    constructor(layoutManager: LayoutManager, config: ResolvedComponentItemConfig,
+    _parentItem: ComponentParentableItem);
     // (undocumented)
     applyUpdatableConfig(config: ResolvedComponentItemConfig): void;
     blur(suppressEvent?: boolean): void;
@@ -205,6 +219,7 @@ export type Config = LayoutConfig;
 
 // @public (undocumented)
 export class ConfigurationError extends ExternalError {
+    // @internal
     constructor(message: string, node?: string | undefined);
     // (undocumented)
     readonly node?: string | undefined;
@@ -213,7 +228,9 @@ export class ConfigurationError extends ExternalError {
 // @public
 export abstract class ContentItem extends EventEmitter {
     // @internal
-    constructor(layoutManager: LayoutManager, config: ResolvedItemConfig, _parent: ContentItem | null, _element: HTMLElement);
+    constructor(layoutManager: LayoutManager, config: ResolvedItemConfig,
+    _parent: ContentItem | null,
+    _element: HTMLElement);
     addChild(contentItem: ContentItem, index?: number | null, suspendResize?: boolean): number;
     // @internal (undocumented)
     addPopInParentId(id: string): void;
@@ -306,6 +323,33 @@ export namespace ContentItem {
 }
 
 // @public
+export class DragSource {
+    // @internal
+    constructor(
+    _layoutManager: LayoutManager,
+    _element: HTMLElement,
+    _extraAllowableChildTargets: HTMLElement[],
+    _componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig),
+    _componentState: JsonValue | undefined,
+    _title: string | undefined);
+    // @internal
+    destroy(): void;
+    }
+
+// @public (undocumented)
+export namespace DragSource {
+    // (undocumented)
+    export interface ComponentItemConfig {
+        // (undocumented)
+        state?: JsonValue;
+        // (undocumented)
+        title?: string;
+        // (undocumented)
+        type: JsonValue;
+    }
+}
+
+// @public
 export class EventEmitter {
     addEventListener<K extends keyof EventEmitter.EventParamsMap>(eventName: K, callback: EventEmitter.Callback<K>): void;
     emit<K extends keyof EventEmitter.EventParamsMap>(eventName: K, ...args: EventEmitter.EventParamsMap[K]): void;
@@ -337,9 +381,12 @@ export namespace EventEmitter {
     export type BeforeComponentReleaseParams = [component: unknown];
     // (undocumented)
     export class BubblingEvent {
-        constructor(_name: string, _target: EventEmitter);
+        // @internal
+        constructor(
+        _name: string,
+        _target: EventEmitter);
         // (undocumented)
-        isPropagationStopped: boolean;
+        get isPropagationStopped(): boolean;
         // (undocumented)
         get name(): string;
         // @deprecated (undocumented)
@@ -355,7 +402,9 @@ export namespace EventEmitter {
     export type Callback<K extends keyof EventEmitter.EventParamsMap> = (this: void, ...args: EventParamsMap[K]) => void;
     // (undocumented)
     export class ClickBubblingEvent extends BubblingEvent {
-        constructor(name: string, target: EventEmitter, _mouseEvent: MouseEvent);
+        // @internal
+        constructor(name: string, target: EventEmitter,
+        _mouseEvent: MouseEvent);
         // (undocumented)
         get mouseEvent(): MouseEvent;
         }
@@ -451,7 +500,9 @@ export namespace EventEmitter {
     export type StringParam = [string];
     // (undocumented)
     export class TouchStartBubblingEvent extends BubblingEvent {
-        constructor(name: string, target: EventEmitter, _touchEvent: TouchEvent);
+        // @internal
+        constructor(name: string, target: EventEmitter,
+        _touchEvent: TouchEvent);
         // (undocumented)
         get touchEvent(): TouchEvent;
         }
@@ -467,6 +518,7 @@ export namespace EventEmitter {
 
 // @public (undocumented)
 export abstract class ExternalError extends Error {
+    // @internal
     constructor(type: string, message: string);
     // (undocumented)
     readonly type: string;
@@ -490,7 +542,19 @@ export namespace GoldenLayout {
 // @public
 export class Header extends EventEmitter {
     // @internal
-    constructor(_layoutManager: LayoutManager, _parent: Stack, settings: Header.Settings, _configClosable: boolean, _getActiveComponentItemEvent: Header.GetActiveComponentItemEvent, closeEvent: Header.CloseEvent, _dockEvent: Header.DockEvent | undefined, _popoutEvent: Header.PopoutEvent | undefined, _maximiseToggleEvent: Header.MaximiseToggleEvent | undefined, _clickEvent: Header.ClickEvent | undefined, _touchStartEvent: Header.TouchStartEvent | undefined, _componentRemoveEvent: Header.ComponentRemoveEvent | undefined, _componentFocusEvent: Header.ComponentFocusEvent | undefined, _componentDragStartEvent: Header.ComponentDragStartEvent | undefined);
+    constructor(
+    _layoutManager: LayoutManager,
+    _parent: Stack, settings: Header.Settings,
+    _configClosable: boolean,
+    _getActiveComponentItemEvent: Header.GetActiveComponentItemEvent, closeEvent: Header.CloseEvent,
+    _dockEvent: Header.DockEvent | undefined,
+    _popoutEvent: Header.PopoutEvent | undefined,
+    _maximiseToggleEvent: Header.MaximiseToggleEvent | undefined,
+    _clickEvent: Header.ClickEvent | undefined,
+    _touchStartEvent: Header.TouchStartEvent | undefined,
+    _componentRemoveEvent: Header.ComponentRemoveEvent | undefined,
+    _componentFocusEvent: Header.ComponentFocusEvent | undefined,
+    _componentDragStartEvent: Header.ComponentDragStartEvent | undefined);
     // @deprecated (undocumented)
     get activeContentItem(): ContentItem | null;
     // @internal (undocumented)
@@ -842,8 +906,8 @@ export namespace LayoutConfig {
 export abstract class LayoutManager extends EventEmitter {
     // @internal
     constructor(parameters: LayoutManager.ConstructorParameters);
-    addComponent(componentType: JsonValue, componentState?: JsonValue): LayoutManager.Location;
-    addComponentAtLocation(componentType: JsonValue, componentState?: JsonValue, locationSelectors?: readonly LayoutManager.LocationSelector[]): LayoutManager.Location | undefined;
+    addComponent(componentType: JsonValue, componentState?: JsonValue, title?: string): LayoutManager.Location;
+    addComponentAtLocation(componentType: JsonValue, componentState?: JsonValue, title?: string, locationSelectors?: readonly LayoutManager.LocationSelector[]): LayoutManager.Location | undefined;
     addItem(itemConfig: RowOrColumnItemConfig | StackItemConfig | ComponentItemConfig): LayoutManager.Location;
     addItemAtLocation(itemConfig: RowOrColumnItemConfig | StackItemConfig | ComponentItemConfig, locationSelectors?: readonly LayoutManager.LocationSelector[]): LayoutManager.Location | undefined;
     // @internal (undocumented)
@@ -859,8 +923,6 @@ export abstract class LayoutManager extends EventEmitter {
     createAndInitContentItem(config: ResolvedItemConfig, parent: ContentItem): ContentItem;
     // @internal
     createContentItem(config: ResolvedItemConfig, parent: ContentItem): ContentItem;
-    // Warning: (ae-forgotten-export) The symbol "DragSource" needs to be exported by the entry point index.d.ts
-    createDragSource(element: HTMLElement, itemConfig: ResolvedComponentItemConfig | (() => ResolvedComponentItemConfig), extraAllowableChildTargets?: HTMLElement[]): DragSource | undefined;
     createPopout(itemConfigOrContentItem: ContentItem | ResolvedRootItemConfig, positionAndSize: ResolvedPopoutLayoutConfig.Window, parentId: string | null, indexInParent: number | null): BrowserPopout;
     // @internal (undocumented)
     createPopoutFromContentItem(item: ContentItem, window: ResolvedPopoutLayoutConfig.Window | undefined, parentId: string | null, indexInParent: number | null | undefined): BrowserPopout;
@@ -908,8 +970,9 @@ export abstract class LayoutManager extends EventEmitter {
     get maximisedStack(): Stack | undefined;
     // @deprecated
     minifyConfig(config: ResolvedLayoutConfig): ResolvedLayoutConfig;
-    newComponent(componentType: JsonValue, componentState?: JsonValue): ComponentItem;
-    newComponentAtLocation(componentType: JsonValue, componentState?: JsonValue, locationSelectors?: LayoutManager.LocationSelector[]): ComponentItem | undefined;
+    newComponent(componentType: JsonValue, componentState?: JsonValue, title?: string): ComponentItem;
+    newComponentAtLocation(componentType: JsonValue, componentState?: JsonValue, title?: string, locationSelectors?: LayoutManager.LocationSelector[]): ComponentItem | undefined;
+    newDragSource(element: HTMLElement, componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig), componentState?: JsonValue, title?: string): DragSource | undefined;
     newItem(itemConfig: RowOrColumnItemConfig | StackItemConfig | ComponentItemConfig): ContentItem;
     newItemAtLocation(itemConfig: RowOrColumnItemConfig | StackItemConfig | ComponentItemConfig, locationSelectors?: readonly LayoutManager.LocationSelector[]): ContentItem | undefined;
     // (undocumented)
@@ -1029,6 +1092,7 @@ export interface LeftAndTop {
 
 // @public (undocumented)
 export class PopoutBlockedError extends ExternalError {
+    // @internal
     constructor(message: string);
 }
 
@@ -1113,7 +1177,7 @@ export namespace ResolvedComponentItemConfig {
     // (undocumented)
     export function createCopy(original: ResolvedComponentItemConfig): ResolvedComponentItemConfig;
     // (undocumented)
-    export function createDefault(): ResolvedComponentItemConfig;
+    export function createDefault(componentType?: JsonValue, componentState?: JsonValue, title?: string): ResolvedComponentItemConfig;
     // @internal (undocumented)
     export function resolveComponentTypeName(itemConfig: ResolvedComponentItemConfig): string | undefined;
 }
@@ -1440,17 +1504,18 @@ export namespace RootItemConfig {
 // @public (undocumented)
 export class RowOrColumn extends ContentItem {
     // @internal
-    constructor(isColumn: boolean, layoutManager: LayoutManager, config: ResolvedRowOrColumnItemConfig, _rowOrColumnParent: ContentItem);
+    constructor(isColumn: boolean, layoutManager: LayoutManager, config: ResolvedRowOrColumnItemConfig,
+    _rowOrColumnParent: ContentItem);
     addChild(contentItem: ContentItem, index?: number, suspendResize?: boolean): number;
     // (undocumented)
-    addComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): number;
+    addComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): number;
     // (undocumented)
     addItem(itemConfig: RowOrColumnItemConfig | StackItemConfig | ComponentItemConfig, index?: number): number;
     dock(contentItem: Stack, mode?: boolean, collapsed?: boolean): void;
     // @internal
     init(): void;
     // (undocumented)
-    newComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): ComponentItem;
+    newComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): ComponentItem;
     // (undocumented)
     newItem(itemConfig: RowOrColumnItemConfig | StackItemConfig | ComponentItemConfig, index?: number): ContentItem;
     removeChild(contentItem: ContentItem, keepChild: boolean): void;
@@ -1512,11 +1577,12 @@ export namespace Side {
 // @public (undocumented)
 export class Stack extends ComponentParentableItem {
     // @internal
-    constructor(layoutManager: LayoutManager, config: ResolvedStackItemConfig, _stackParent: Stack.Parent);
+    constructor(layoutManager: LayoutManager, config: ResolvedStackItemConfig,
+    _stackParent: Stack.Parent);
     // (undocumented)
     addChild(contentItem: ContentItem, index?: number, focus?: boolean): number;
     // (undocumented)
-    addComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): number;
+    addComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): number;
     // (undocumented)
     addItem(itemConfig: ComponentItemConfig, index?: number): number;
     // (undocumented)
@@ -1558,7 +1624,7 @@ export class Stack extends ComponentParentableItem {
     // (undocumented)
     minimise(): void;
     // (undocumented)
-    newComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): ComponentItem;
+    newComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): ComponentItem;
     // (undocumented)
     newItem(itemConfig: ComponentItemConfig, index?: number): ContentItem;
     // @internal
@@ -1660,7 +1726,12 @@ export namespace StackItemConfig {
 // @public
 export class Tab {
     // @internal
-    constructor(_layoutManager: LayoutManager, _componentItem: ComponentItem, _closeEvent: Tab.CloseEvent | undefined, _focusEvent: Tab.FocusEvent | undefined, _dragStartEvent: Tab.DragStartEvent | undefined);
+    constructor(
+    _layoutManager: LayoutManager,
+    _componentItem: ComponentItem,
+    _closeEvent: Tab.CloseEvent | undefined,
+    _focusEvent: Tab.FocusEvent | undefined,
+    _dragStartEvent: Tab.DragStartEvent | undefined);
     // (undocumented)
     get closeElement(): HTMLElement | undefined;
     // (undocumented)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-layout",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './ts/config/config';
 export * from './ts/config/resolved-config';
 export { ComponentContainer } from './ts/container/component-container';
 export { BrowserPopout } from './ts/controls/browser-popout';
+export { DragSource } from './ts/controls/drag-source';
 export { Header } from './ts/controls/header';
 export { Tab } from './ts/controls/tab';
 export * from './ts/errors/external-error';

--- a/src/ts/config/resolved-config.ts
+++ b/src/ts/config/resolved-config.ts
@@ -227,7 +227,7 @@ export namespace ResolvedComponentItemConfig {
         return result;
     }
 
-    export function createDefault(): ResolvedComponentItemConfig {
+    export function createDefault(componentType: JsonValue = '', componentState?: JsonValue, title = ''): ResolvedComponentItemConfig {
         const result: ResolvedComponentItemConfig = {
             type: ItemType.component,
             content: [],
@@ -239,10 +239,10 @@ export namespace ResolvedComponentItemConfig {
             maximised: ResolvedHeaderedItemConfig.defaultMaximised,
             isClosable: ResolvedItemConfig.defaults.isClosable,
             reorderEnabled: ResolvedComponentItemConfig.defaultReorderEnabled,
-            title: '',
+            title,
             header: undefined,
-            componentType: '',
-            componentState: {},
+            componentType,
+            componentState,
         }
         return result;
     }

--- a/src/ts/container/component-container.ts
+++ b/src/ts/container/component-container.ts
@@ -52,14 +52,24 @@ export class ComponentContainer extends EventEmitter {
     get element(): HTMLElement { return this._element; }
 
     /** @internal */
-    constructor(private readonly _config: ResolvedComponentItemConfig,
+    constructor(
+        /** @internal */
+        private readonly _config: ResolvedComponentItemConfig,
+        /** @internal */
         private readonly _parent: ComponentItem,
+        /** @internal */
         private readonly _layoutManager: LayoutManager,
+        /** @internal */
         private readonly _element: HTMLElement,
+        /** @internal */
         private readonly _updateItemConfigEvent: ComponentContainer.UpdateItemConfigEventHandler,
+        /** @internal */
         private readonly _showEvent: ComponentContainer.ShowEventHandler,
+        /** @internal */
         private readonly _hideEvent: ComponentContainer.HideEventHandler,
+        /** @internal */
         private readonly _focusEvent: ComponentContainer.FocusEventHandler,
+        /** @internal */
         private readonly _blurEvent: ComponentContainer.BlurEventHandler,
     ) {
         super();
@@ -302,6 +312,7 @@ export class ComponentContainer extends EventEmitter {
         }
     }
 
+    /** @internal */
     private releaseComponent() {
         this.emit('beforeComponentRelease', this._component);
         this.layoutManager.releaseComponent(this, this._component);

--- a/src/ts/controls/browser-popout.ts
+++ b/src/ts/controls/browser-popout.ts
@@ -32,8 +32,12 @@ export class BrowserPopout extends EventEmitter {
      * @param _initialWindowSize - A map with width, height, top and left
      * @internal
      */
-    constructor(private _config: ResolvedPopoutLayoutConfig,
+    constructor(
+        /** @internal */
+        private _config: ResolvedPopoutLayoutConfig,
+        /** @internal */
         private _initialWindowSize: Rect,
+        /** @internal */
         private _layoutManager: LayoutManager,
     ) {
         super();

--- a/src/ts/controls/drag-proxy.ts
+++ b/src/ts/controls/drag-proxy.ts
@@ -114,6 +114,25 @@ export class DragProxy extends EventEmitter {
             this._width = elementWidth;
             this._height = elementHeight;
 
+
+            if (this._layoutManager.layoutConfig.settings.constrainDragToContainer) {
+                if (x <= this._minX) {
+                    x = Math.ceil(this._minX + 1);
+                } else {
+                    if (x >= this._maxX) {
+                        x = Math.floor(this._maxX - 1);
+                    }
+                }
+
+                if (y <= this._minY) {
+                    y = Math.ceil(this._minY + 1);
+                } else {
+                    if (y >= this._maxY) {
+                        y = Math.floor(this._maxY - 1);
+                    }
+                }
+            }
+    
             this.setDropPosition(x, y);
         }
     }
@@ -132,13 +151,15 @@ export class DragProxy extends EventEmitter {
 
         const x = event.pageX;
         const y = event.pageY;
-        const isWithinContainer = x > this._minX && x < this._maxX && y > this._minY && y < this._maxY;
 
-        if (!isWithinContainer && this._layoutManager.layoutConfig.settings?.constrainDragToContainer === true) {
-            return;
+        if (!this._layoutManager.layoutConfig.settings.constrainDragToContainer) {
+            this.setDropPosition(x, y);
+        } else {
+            const isWithinContainer = x > this._minX && x < this._maxX && y > this._minY && y < this._maxY;
+            if (isWithinContainer) {
+                this.setDropPosition(x, y);
+            }
         }
-
-        this.setDropPosition(x, y);
     }
 
     /**

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -113,19 +113,32 @@ export class Header extends EventEmitter {
     get controlsContainer(): HTMLElement { return this._controlsContainerElement; }
 
     /** @internal */
-    constructor(private _layoutManager: LayoutManager,
+    constructor(
+        /** @internal */
+        private _layoutManager: LayoutManager,
+        /** @internal */
         private _parent: Stack,
         settings: Header.Settings,
+        /** @internal */
         private readonly _configClosable: boolean,
+        /** @internal */
         private _getActiveComponentItemEvent: Header.GetActiveComponentItemEvent,
         closeEvent: Header.CloseEvent,
+        /** @internal */
         private _dockEvent: Header.DockEvent | undefined,
+        /** @internal */
         private _popoutEvent: Header.PopoutEvent | undefined,
+        /** @internal */
         private _maximiseToggleEvent: Header.MaximiseToggleEvent | undefined,
+        /** @internal */
         private _clickEvent: Header.ClickEvent | undefined,
+        /** @internal */
         private _touchStartEvent: Header.TouchStartEvent | undefined,
+        /** @internal */
         private _componentRemoveEvent: Header.ComponentRemoveEvent | undefined,
+        /** @internal */
         private _componentFocusEvent: Header.ComponentFocusEvent | undefined,
+        /** @internal */
         private _componentDragStartEvent: Header.ComponentDragStartEvent | undefined,
     ) {
         super();
@@ -399,6 +412,7 @@ export class Header extends EventEmitter {
         }
     }
 
+    /** @internal */
     private processTabDropdownActiveChanged() {
         setElementDisplayVisibility(this._tabDropdownButton.element, this._tabsContainer.dropdownActive);
     }

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -36,6 +36,7 @@ export class Tab {
     private readonly _dragStartListener = (x: number, y: number) => this.onDragStart(x, y);
     /** @internal */
     private readonly _contentItemDestroyListener = () => this.onContentItemDestroy();
+    /** @internal */
     private readonly _tabTitleChangedListener = (title: string) => this.setTitle(title)
 
     get isActive(): boolean { return this._isActive; }
@@ -48,10 +49,16 @@ export class Tab {
     get closeElement(): HTMLElement | undefined { return this._closeElement; }
 
     /** @internal */
-    constructor(private readonly _layoutManager: LayoutManager,
+    constructor(
+        /** @internal */
+        private readonly _layoutManager: LayoutManager,
+        /** @internal */
         private _componentItem: ComponentItem,
+        /** @internal */
         private _closeEvent: Tab.CloseEvent | undefined,
+        /** @internal */
         private _focusEvent: Tab.FocusEvent | undefined,
+        /** @internal */
         private _dragStartEvent: Tab.DragStartEvent | undefined
     ) {
         this._element = document.createElement('div');

--- a/src/ts/errors/external-error.ts
+++ b/src/ts/errors/external-error.ts
@@ -1,5 +1,6 @@
 /** @public */
 export abstract class ExternalError extends Error {
+    /** @internal */
     constructor(public readonly type: string, message: string) {
         super(message);
     }
@@ -7,6 +8,7 @@ export abstract class ExternalError extends Error {
 
 /** @public */
 export class ConfigurationError extends ExternalError {
+    /** @internal */
     constructor(message: string, public readonly node?: string) {
         super('Configuration', message);
     }
@@ -14,6 +16,7 @@ export class ConfigurationError extends ExternalError {
 
 /** @public */
 export class PopoutBlockedError extends ExternalError {
+    /** @internal */
     constructor(message: string) {
         super('PopoutBlocked', message);
     }    
@@ -21,6 +24,7 @@ export class PopoutBlockedError extends ExternalError {
 
 /** @public */
 export class ApiError extends ExternalError {
+    /** @internal */
     constructor(message: string) {
         super('API', message);
     }    

--- a/src/ts/items/component-item.ts
+++ b/src/ts/items/component-item.ts
@@ -42,8 +42,10 @@ export class ComponentItem extends ContentItem {
     get focused(): boolean { return this._focused; }
 
     /** @internal */
-    constructor(layoutManager: LayoutManager,
+    constructor(
+        layoutManager: LayoutManager,
         config: ResolvedComponentItemConfig,
+        /** @internal */
         private _parentItem: ComponentParentableItem
     ) {
         super(layoutManager, config, _parentItem, document.createElement('div'));

--- a/src/ts/items/component-parentable-item.ts
+++ b/src/ts/items/component-parentable-item.ts
@@ -2,6 +2,7 @@ import { ComponentItem } from './component-item';
 import { ContentItem } from './content-item';
 
 export abstract class ComponentParentableItem extends ContentItem {
+    /** @internal */
     private _focused = false;
 
     get focused(): boolean { return this._focused; }

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -76,7 +76,9 @@ export abstract class ContentItem extends EventEmitter {
     /** @internal */
     constructor(public readonly layoutManager: LayoutManager,
         config: ResolvedItemConfig,
+        /** @internal */
         private _parent: ContentItem | null,
+        /** @internal */
         private readonly _element: HTMLElement
     ) {
         super();

--- a/src/ts/items/ground-item.ts
+++ b/src/ts/items/ground-item.ts
@@ -1,9 +1,9 @@
 import { ComponentItemConfig, ItemConfig, RowOrColumnItemConfig, StackItemConfig } from '../config/config';
 import { ResolvedComponentItemConfig, ResolvedGroundItemConfig, ResolvedHeaderedItemConfig, ResolvedItemConfig, ResolvedRootItemConfig, ResolvedStackItemConfig } from '../config/resolved-config';
-import { AssertError, UnexpectedNullError, UnexpectedUndefinedError } from '../errors/internal-error';
+import { AssertError, UnexpectedNullError } from '../errors/internal-error';
 import { LayoutManager } from '../layout-manager';
 import { DomConstants } from '../utils/dom-constants';
-import { AreaLinkedRect, ItemType, JsonValue } from '../utils/types';
+import { AreaLinkedRect, ItemType } from '../utils/types';
 import { getElementWidthAndHeight, setElementHeight, setElementWidth } from '../utils/utils';
 import { ComponentItem } from './component-item';
 import { ComponentParentableItem } from './component-parentable-item';
@@ -55,51 +55,6 @@ export class GroundItem extends ComponentParentableItem {
         if (rootItemConfig !== undefined) {
             const rootContentItem = this.layoutManager.createAndInitContentItem(rootItemConfig, this);
             this.addChild(rootContentItem, 0);
-        }
-    }
-
-    newComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): ComponentItem {
-        const itemConfig: ComponentItemConfig = {
-            type: 'component',
-            componentType,
-            componentState,
-        };
-        return this.newItem(itemConfig, index) as ComponentItem;
-    }
-
-    /**
-     * Adds a Component child to root ContentItem.
-     * Internal only.  To load a add with API, use {@link (LayoutManager:class).addComponent}
-     */
-    addComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): number {
-        const itemConfig: ComponentItemConfig = {
-            type: 'component',
-            componentType,
-            componentState,
-        };
-        return this.addItem(itemConfig, index);
-    }
-
-    newItem(itemConfig: RowOrColumnItemConfig | StackItemConfig | ComponentItemConfig,  index?: number): ContentItem {
-        index = this.addItem(itemConfig, index);
-        let createdItem: ContentItem;
-        if (index === -1) {
-            // created ContentItem as root as root did not exist
-            createdItem = this.contentItems[0];
-        } else {
-            const rootItem = this.contentItems[0];
-            if (rootItem === undefined) {
-                throw new UnexpectedUndefinedError('GINI8832');
-            } else {
-                createdItem = rootItem.contentItems[index];
-            }
-        }
-
-        if (ContentItem.isStack(createdItem) && (ItemConfig.isComponent(itemConfig))) {
-            // createdItem is a Stack which was created to hold wanted component.  Return component
-            return createdItem.contentItems[0];
-        } else {
-            return createdItem;
         }
     }
 

--- a/src/ts/items/row-or-column.ts
+++ b/src/ts/items/row-or-column.ts
@@ -44,6 +44,7 @@ export class RowOrColumn extends ContentItem {
 
     /** @internal */
     constructor(isColumn: boolean, layoutManager: LayoutManager, config: ResolvedRowOrColumnItemConfig,
+        /** @internal */
         private _rowOrColumnParent: ContentItem
     ) {
         super(layoutManager, config, _rowOrColumnParent, RowOrColumn.createElement(document, isColumn));
@@ -70,20 +71,22 @@ export class RowOrColumn extends ContentItem {
         }
     }
 
-    newComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): ComponentItem {
+    newComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): ComponentItem {
         const itemConfig: ComponentItemConfig = {
             type: 'component',
             componentType,
             componentState,
+            title,
         };
         return this.newItem(itemConfig, index) as ComponentItem;
     }
 
-    addComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): number {
+    addComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): number {
         const itemConfig: ComponentItemConfig = {
             type: 'component',
             componentType,
             componentState,
+            title,
         };
         return this.addItem(itemConfig, index);
     }

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -71,7 +71,10 @@ export class Stack extends ComponentParentableItem {
     get isMaximised(): boolean { return this === this.layoutManager.maximisedStack; }
 
     /** @internal */
-    constructor(layoutManager: LayoutManager, config: ResolvedStackItemConfig, private _stackParent: Stack.Parent) {
+    constructor(layoutManager: LayoutManager, config: ResolvedStackItemConfig,
+        /** @internal */
+        private _stackParent: Stack.Parent
+    ) {
         super(layoutManager, config, _stackParent, Stack.createElement(document));
 
         this._headerConfig = config.header;
@@ -293,20 +296,22 @@ export class Stack extends ComponentParentableItem {
         this._header.setRowColumnClosable(value);
     }
 
-    newComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): ComponentItem {
+    newComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): ComponentItem {
         const itemConfig: ComponentItemConfig = {
             type: 'component',
             componentType,
             componentState,
+            title,
         };
         return this.newItem(itemConfig, index) as ComponentItem;
     }
 
-    addComponent(componentType: JsonValue, componentState?: JsonValue, index?: number): number {
+    addComponent(componentType: JsonValue, componentState?: JsonValue, title?: string, index?: number): number {
         const itemConfig: ComponentItemConfig = {
             type: 'component',
             componentType,
             componentState,
+            title,
         };
         return this.addItem(itemConfig, index);
     }
@@ -848,6 +853,7 @@ export class Stack extends ComponentParentableItem {
         return;
     }
 
+    /** @internal */
     private resetHeaderDropZone() {
         this.layoutManager.tabDropPlaceholder.remove();
     }

--- a/src/ts/utils/event-emitter.ts
+++ b/src/ts/utils/event-emitter.ts
@@ -140,6 +140,7 @@ export class EventEmitter {
         }
     }
 
+    /** @internal */
     private emitAllEvent(eventName: string, args: unknown[]) {
         const allEventSubscriptionsCount = this._allEventSubscriptions.length;
         if (allEventSubscriptionsCount > 0) {
@@ -217,25 +218,36 @@ export namespace EventEmitter {
     export type TouchStartBubblingEventParam = [TouchStartBubblingEvent];
 
     export class BubblingEvent {
-        isPropagationStopped = false;
+        /** @internal */
+        private _isPropagationStopped = false;
 
         get name(): string { return this._name; }
         get target(): EventEmitter { return this._target; }
         /** @deprecated Use {@link (EventEmitter:namespace).(BubblingEvent:class).target} instead */
         get origin(): EventEmitter { return this._target; }
+        get isPropagationStopped(): boolean { return this._isPropagationStopped; }
     
-        constructor(private readonly _name: string, private readonly _target: EventEmitter) {
+        /** @internal */
+        constructor(
+            /** @internal */
+            private readonly _name: string,
+            /** @internal */
+            private readonly _target: EventEmitter) {
         }
     
         stopPropagation(): void {
-            this.isPropagationStopped = true;
+            this._isPropagationStopped = true;
         }
     }
 
     export class ClickBubblingEvent extends BubblingEvent {
         get mouseEvent(): MouseEvent { return this._mouseEvent; }
 
-        constructor(name: string, target: EventEmitter, private readonly _mouseEvent: MouseEvent) {
+        /** @internal */
+        constructor(name: string, target: EventEmitter,
+            /** @internal */
+            private readonly _mouseEvent: MouseEvent
+        ) {
             super(name, target);
         }
     }
@@ -243,7 +255,11 @@ export namespace EventEmitter {
     export class TouchStartBubblingEvent extends BubblingEvent {
         get touchEvent(): TouchEvent { return this._touchEvent; }
 
-        constructor(name: string, target: EventEmitter, private readonly _touchEvent: TouchEvent) {
+        /** @internal */
+        constructor(name: string, target: EventEmitter,
+            /** @internal */
+            private readonly _touchEvent: TouchEvent
+        ) {
             super(name, target);
         }
     }


### PR DESCRIPTION
Release 2.0.1:
DragSources can now be created with `LayoutManager.newDragSource()`.
New/AddComponent() functions can now specify title as well.
Private entries removed from TypeScript definition.