### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ export default defineComponent({
     };
     const destroyComponent = (toBeRemoved: HTMLElement) => {
       componentInstances.value = componentInstances.value.filter(
-        ({ element }) => element === toBeRemoved
+        ({ element }) => element !== toBeRemoved
       );
     };
 


### PR DESCRIPTION
As mentioned here:
>> Vue users may wish to review @lanyizi's PR and the revised example.
> 
> Just discovered that there is (another) typo in my example.
Inside `destroyComponent`'s `Array.filter()`, it should have been `element != toBeRemoved` instead of `element === toBeRemoved` 
Sorry for that xD

_Originally posted by @lanyizi in https://github.com/golden-layout/golden-layout/issues/158#issuecomment-811300932_