### PR TITLE
Use shallowRef in the Vue example of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ The following snippets of code demonstrate how Golden Layout can be used in Vue.
 
 ```ts
 import { GoldenLayout, LayoutConfig } from 'golden-layout';
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, shallowRef } from 'vue';
 
 export const isClient = typeof window !== 'undefined';
 export const isDocumentReady = () => isClient && document.readyState === 'complete' && document.body != null;
@@ -280,8 +280,8 @@ export function useGoldenLayout(
     destroyComponent: (container: HTMLElement) => void,
     config?: LayoutConfig
 ) {
-    const element = ref<HTMLElement | null>(null);
-    const layout = ref<GoldenLayout | null>(null);
+    const element = shallowRef<HTMLElement | null>(null);
+    const layout = shallowRef<GoldenLayout | null>(null);
     const initialized = ref(false);
 
     useDocumentReady(() => {
@@ -324,7 +324,7 @@ export function useGoldenLayout(
 </template>
 <script lang="ts">
 import { useGoldenLayout } from "@/use-golden-layout";
-import { defineComponent, h, ref } from "vue";
+import { defineComponent, h, ref, shallowRef } from "vue";
 import "golden-layout/dist/css/goldenlayout-base.css";
 import "golden-layout/dist/css/themes/goldenlayout-dark-theme.css";
 
@@ -342,7 +342,7 @@ export default defineComponent({
     }
     let instanceId = 0;
     const componentTypes = new Set(Object.keys(components));
-    const componentInstances = ref<ComponentInstance[]>([]);
+    const componentInstances = shallowRef<ComponentInstance[]>([]);
 
     const createComponent = (type: string, element: HTMLElement) => {
       if (!componentTypes.has(type)) {

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ export function useGoldenLayout(
 </template>
 <script lang="ts">
 import { useGoldenLayout } from "@/use-golden-layout";
-import { defineComponent, h, ref, shallowRef } from "vue";
+import { defineComponent, h, shallowRef } from "vue";
 import "golden-layout/dist/css/goldenlayout-base.css";
 import "golden-layout/dist/css/themes/goldenlayout-dark-theme.css";
 


### PR DESCRIPTION
I'm really sorry for bothering you once again with my pull requests, but... <img src="https://user-images.githubusercontent.com/2989995/113370574-80b09180-9364-11eb-8c96-661767de5858.png" width="64">

If an object is assigned as a Vue `ref`'s value, the object is made deeply reactive by the `reactive` method.
This might introduce [some issues in some circumstances](https://v3.vuejs.org/api/basic-reactivity.html#reactive), because a reactive wrapper has been created:
> In the [ES2015 Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) based implementation, the returned proxy is **not** equal to the original object. It is recommended to work exclusively with the reactive proxy and avoid relying on the original object.

It wasn't until now that I discovered that the returned `Ref<GoldenLayout>` (which contains a reactive wrapper of `GoldenLayout` instance in its value) might have issues in few cases, so I'm creating this pull request to change most of `ref`s to [`shallowRef`](https://v3.vuejs.org/api/refs-api.html#shallowref). The `shallowRef` funciton won't make its value reactive, and I think we don't need to have reactive `GoldenLayout` instances...