### PR TITLE
Fix: Splitter drag consumed by browser

### DIFF
--- a/src/less/goldenlayout-base.less
+++ b/src/less/goldenlayout-base.less
@@ -61,12 +61,14 @@
 .lm_splitter {
   position: relative;
   z-index: 2;
+  touch-action: none;
 
   &.lm_vertical {
     .lm_drag_handle {
       width: @width0;
       position: absolute;
       cursor: ns-resize;
+      touch-action: none;
     }
   }
 
@@ -78,6 +80,7 @@
       height: @height0;
       position: absolute;
       cursor: ew-resize;
+      touch-action: none;
     }
   }
 }

--- a/src/scss/goldenlayout-base.scss
+++ b/src/scss/goldenlayout-base.scss
@@ -61,12 +61,14 @@ $height6: 15px; // Appears 1 time
 .lm_splitter {
   position: relative;
   z-index: 2;
+  touch-action: none;
 
   &.lm_vertical {
     .lm_drag_handle {
       width: $width0;
       position: absolute;
       cursor: ns-resize;
+      touch-action: none;
     }
   }
 
@@ -78,6 +80,7 @@ $height6: 15px; // Appears 1 time
       height: $height0;
       position: absolute;
       cursor: ew-resize;
+      touch-action: none;
     }
   }
 }
@@ -253,6 +256,7 @@ $height6: 15px; // Appears 1 time
 
       .lm_controls {
         bottom: 0;
+        flex-flow: column;
       }
     }
   }

--- a/src/ts/utils/drag-listener.ts
+++ b/src/ts/utils/drag-listener.ts
@@ -76,7 +76,7 @@ export class DragListener extends EventEmitter {
         this._nOriginalX = coordinates.x;
         this._nOriginalY = coordinates.y;
 
-        this._oDocument.addEventListener('pointermove', this._pointerMoveEventListener, { passive: true });
+        this._oDocument.addEventListener('pointermove', this._pointerMoveEventListener);
         this._oDocument.addEventListener('pointerup', this._pointerUpEventListener, { passive: true });
         this._pointerTracking = true;
 
@@ -96,6 +96,7 @@ export class DragListener extends EventEmitter {
     private onPointerMove(oEvent: PointerEvent) {
         if (this._pointerTracking) {
             this.processDragMove(oEvent);
+            oEvent.preventDefault();
         }
     }
 


### PR DESCRIPTION
Fixes bug where splitter is not working correctly
preventDefault() needs to be called on pointer move event to stop browser consuming these events. (It wants to check for gestures)