### PR TITLE
Add proper type information to events with parameters

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -411,6 +411,8 @@ export namespace EventEmitter {
     // (undocumented)
     export type ClickBubblingEventParam = [ClickBubblingEvent];
     // (undocumented)
+    export type ComponentItemParam = [ComponentItem];
+    // (undocumented)
     export type DragParams = [offsetX: number, offsetY: number, event: PointerEvent];
     // (undocumented)
     export type DragStartParams = [originalX: number, originalY: number];
@@ -421,7 +423,7 @@ export namespace EventEmitter {
         // (undocumented)
         "__all": UnknownParams;
         // (undocumented)
-        "activeContentItemChanged": UnknownParam;
+        "activeContentItemChanged": ComponentItemParam;
         // (undocumented)
         "beforeComponentRelease": BeforeComponentReleaseParams;
         // (undocumented)
@@ -451,7 +453,7 @@ export namespace EventEmitter {
         // (undocumented)
         "itemDestroyed": BubblingEventParam;
         // (undocumented)
-        "itemDropped": UnknownParam;
+        "itemDropped": ComponentItemParam;
         // (undocumented)
         "maximised": NoParams;
         // (undocumented)
@@ -473,22 +475,26 @@ export namespace EventEmitter {
         // (undocumented)
         "stateChanged": NoParams;
         // (undocumented)
-        "tab": UnknownParam;
+        "tab": TabParam;
         // (undocumented)
-        "tabCreated": UnknownParam;
+        "tabCreated": TabParam;
         // (undocumented)
         "titleChanged": StringParam;
         // (undocumented)
         "userBroadcast": UnknownParams;
         // (undocumented)
-        "windowClosed": UnknownParam;
+        "windowClosed": PopoutParam;
         // (undocumented)
-        "windowOpened": UnknownParam;
+        "windowOpened": PopoutParam;
     }
     // (undocumented)
     export type NoParams = [];
     // (undocumented)
+    export type PopoutParam = [BrowserPopout];
+    // (undocumented)
     export type StringParam = [string];
+    // (undocumented)
+    export type TabParam = [Tab];
     // (undocumented)
     export class TouchStartBubblingEvent extends BubblingEvent {
         // @internal

--- a/src/ts/utils/event-emitter.ts
+++ b/src/ts/utils/event-emitter.ts
@@ -1,3 +1,7 @@
+import { BrowserPopout } from '../controls/browser-popout';
+import { Tab } from '../controls/tab';
+import { ComponentItem } from '../items/component-item';
+
 /**
  * A generic and very fast EventEmitter implementation. On top of emitting the actual event it emits an
  * {@link (EventEmitter:namespace).ALL_EVENT} event for every event triggered. This allows to hook into it and proxy events forwards
@@ -172,7 +176,7 @@ export namespace EventEmitter {
 
     export interface EventParamsMap {
         "__all": UnknownParams;
-        "activeContentItemChanged": UnknownParam;
+        "activeContentItemChanged": ComponentItemParam;
         "close": NoParams;
         "closed": NoParams;
         "destroy": NoParams;
@@ -181,7 +185,7 @@ export namespace EventEmitter {
         "dragStop": DragStopParams;
         "hide": NoParams;
         "initialised": NoParams;
-        "itemDropped": UnknownParam;
+        "itemDropped": ComponentItemParam;
         "maximised": NoParams;
         "minimised": NoParams;
         "open": NoParams;
@@ -191,11 +195,11 @@ export namespace EventEmitter {
         /** @deprecated - use show instead */
         "shown": NoParams;
         "stateChanged": NoParams;
-        "tab": UnknownParam;
-        "tabCreated": UnknownParam;
+        "tab": TabParam;
+        "tabCreated": TabParam;
         "titleChanged": StringParam;
-        "windowClosed": UnknownParam;
-        "windowOpened": UnknownParam;
+        "windowClosed": PopoutParam;
+        "windowOpened": PopoutParam;
         "beforeComponentRelease": BeforeComponentReleaseParams;
         "beforeItemDestroyed": BubblingEventParam;
         "itemCreated": BubblingEventParam;
@@ -210,6 +214,9 @@ export namespace EventEmitter {
     export type UnknownParams = unknown[];
     export type NoParams = [];
     export type UnknownParam = [unknown];
+    export type PopoutParam = [BrowserPopout];
+    export type ComponentItemParam = [ComponentItem];
+    export type TabParam = [Tab];
     export type BubblingEventParam = [EventEmitter.BubblingEvent]
     export type StringParam = [string];
     export type DragStartParams = [originalX: number, originalY: number];


### PR DESCRIPTION
This PR properly types the following events: 

- `tab`/`tabCreated`
- `windowOpened`/`windowClosed`
- `activeContentItemChanged`
- `itemDropped`

While this changes the public API signature, it does so in a backwards compatible way, since a user would have to use type checks anyway on the previously unknown type anyway, whereas now those events are properly typed.