### PR TITLE
Fix implementation of stripTags.  Don't use it for Tab.setTitle, though

### DIFF
--- a/src/ts/controls/drag-proxy.ts
+++ b/src/ts/controls/drag-proxy.ts
@@ -10,8 +10,7 @@ import { getJQueryOffset } from '../utils/jquery-legacy';
 import { Side } from '../utils/types';
 import {
     getElementWidthAndHeight,
-    numberToPixels,
-    stripTags
+    numberToPixels
 } from '../utils/utils';
 
 /**
@@ -34,7 +33,7 @@ export class DragProxy extends EventEmitter {
 
     get element(): HTMLElement { return this._element; }
 
-    /** 
+    /**
      * @param x - The initial x position
      * @param y - The initial y position
      * @internal
@@ -109,7 +108,7 @@ export class DragProxy extends EventEmitter {
         }
         this._element.style.left = numberToPixels(initialX);
         this._element.style.top = numberToPixels(initialY);
-        tabElement.setAttribute('title', stripTags(this._componentItem.title));
+        tabElement.setAttribute('title', this._componentItem.title);
         titleElement.insertAdjacentText('afterbegin', this._componentItem.title);
         this._proxyContainerElement.appendChild(this._componentItem.element);
     }
@@ -129,14 +128,14 @@ export class DragProxy extends EventEmitter {
         } else if (x >= this._maxX) {
             x = Math.floor(this._maxX - 1);
         }
-        
+
         if (y <= this._minY) {
             y = Math.ceil(this._minY + 1);
         } else if (y >= this._maxY) {
             y = Math.floor(this._maxY - 1);
         }
-        
-        return {x,y};   
+
+        return {x,y};
     }
 
     /**
@@ -249,13 +248,13 @@ export class DragProxy extends EventEmitter {
         if (dimensions === undefined) {
             throw new Error('DragProxy.setDimensions: dimensions undefined');
         }
-        
+
         let width = dimensions.dragProxyWidth;
         let height = dimensions.dragProxyHeight;
         if (width === undefined || height === undefined) {
             throw new Error('DragProxy.setDimensions: width and/or height undefined');
         }
-    
+
         const headerHeight = this._layoutManager.layoutConfig.header.show === false ? 0 : dimensions.headerHeight;
         this._element.style.width = numberToPixels(width);
         this._element.style.height = numberToPixels(height)

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -3,7 +3,6 @@ import { ComponentItem } from '../items/component-item';
 import { LayoutManager } from '../layout-manager';
 import { DomConstants } from '../utils/dom-constants';
 import { DragListener } from '../utils/drag-listener';
-import { stripTags } from '../utils/utils';
 
 /**
  * Represents an individual tab within a Stack's header
@@ -117,8 +116,8 @@ export class Tab {
      * html tags) of the same string.
      */
     setTitle(title: string): void {
-        this._titleElement.innerHTML = title;
-        this._element.title = this._titleElement.innerText; // = stripTags(title)
+        this._titleElement.innerText = title;
+        this._element.title = title;
     }
 
     /**

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -117,8 +117,8 @@ export class Tab {
      * html tags) of the same string.
      */
     setTitle(title: string): void {
-        this._element.title = stripTags(title);
-        this._titleElement.innerText = title;
+        this._titleElement.innerHTML = title;
+        this._element.title = this._titleElement.innerText; // = stripTags(title)
     }
 
     /**

--- a/src/ts/utils/utils.ts
+++ b/src/ts/utils/utils.ts
@@ -152,6 +152,7 @@ export function getUniqueId(): string {
  * @internal
 */
 export function stripTags(input: string): string {
-    const strippedInput = input.replace(/(<([^>]+)>)/ig, '');
-    return strippedInput.trim();
+    const tmp = document.createElement("span");
+    tmp.innerHTML = input;
+    return tmp.innerText.trim();
 }

--- a/src/ts/utils/utils.ts
+++ b/src/ts/utils/utils.ts
@@ -145,14 +145,3 @@ export function getUniqueId(): string {
         .toString(36)
         .replace('.', '');
 }
-
-/**
- * Removes html tags from a string
- * @returns input without tags
- * @internal
-*/
-export function stripTags(input: string): string {
-    const tmp = document.createElement("span");
-    tmp.innerHTML = input;
-    return tmp.innerText.trim();
-}


### PR DESCRIPTION
If the input to stripTags is allowed to be HTML, then the old
implementation failed to handle character entities.  Hence no
way to create a title containing '<' or '>'.  A simple fix is
to parse parse the input as HTML (using innerHTML on a temporary element)
and extract the text (using innerText).

Also, for Tab.setTitle, it is useful to actually allow HTML,
so don't use stripTags.