### PR TITLE
WIP: Support content-element outside root element

### DIFF
--- a/src/ts/container/component-container.ts
+++ b/src/ts/container/component-container.ts
@@ -7,7 +7,7 @@ import { ContentItem } from '../items/content-item';
 import { LayoutManager } from '../layout-manager';
 import { EventEmitter } from '../utils/event-emitter';
 import { JsonValue } from '../utils/types';
-import { deepExtend, setElementHeight, setElementWidth } from '../utils/utils';
+import { deepExtend, setElementHeight, setElementWidth, numberToPixels } from '../utils/utils';
 
 /** @public */
 export class ComponentContainer extends EventEmitter {
@@ -311,6 +311,13 @@ export class ComponentContainer extends EventEmitter {
             this._height = height;
             setElementWidth(this._element, width);
             setElementHeight(this._element, height);
+            if (this._element.parentNode !== this.parent.element) {
+                const box = this.parent.element.getBoundingClientRect();
+                const root = this.layoutManager.container.getBoundingClientRect();
+                this._element.style.position = "absolute";
+                this._element.style.left = numberToPixels(box.x - root.x);
+                this._element.style.top = numberToPixels(box.y - root.y);
+            }
             this.emit('resize');
             if (this._isShownWithZeroDimensions && (this._height !== 0 || this._width !== 0)) {
                 this._isShownWithZeroDimensions = false;
@@ -322,8 +329,9 @@ export class ComponentContainer extends EventEmitter {
 
     /** @internal */
     private releaseComponent() {
-        this.emit('beforeComponentRelease', this._component);
-        this.layoutManager.releaseComponent(this, this._component);
+        const component = this._component || this._element;
+        this.emit('beforeComponentRelease', component);
+        this.layoutManager.releaseComponent(this, component);
     }
 }
 

--- a/src/ts/controls/tabs-container.ts
+++ b/src/ts/controls/tabs-container.ts
@@ -130,6 +130,8 @@ export class TabsContainer {
      * Pushes the tabs to the tab dropdown if the available space is not sufficient
      */
     updateTabSizes(availableWidth: number, activeComponentItem: ComponentItem | undefined): void {
+        if (!activeComponentItem)
+            return;
         let dropDownActive = false;
         const success = this.tryUpdateTabSizes(dropDownActive, availableWidth, activeComponentItem);
         if (!success) {

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -103,7 +103,7 @@ export abstract class ContentItem extends EventEmitter {
         this._pendingEventPropagations = {};
         this._throttledEvents = ['stateChanged'];
 
-        this._contentItems = this.createContentItems(config.content);
+        this._contentItems = this.createContentItems(config.content || []);
     }
 
     /**

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -662,7 +662,7 @@ export class Stack extends ComponentParentableItem {
 
     /** @internal */
     private updateNodeSize(): void {
-        if (this.element.style.display !== 'none') {
+        if (this.element.parentNode && this.element.style.display !== 'none') {
             const content: WidthAndHeight = getElementWidthAndHeight(this.element);
 
             if (this._header.show) {

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -103,6 +103,7 @@ export abstract class LayoutManager extends EventEmitter {
 
     readonly isSubWindow: boolean;
     layoutConfig: ResolvedLayoutConfig;
+    componentParent: HTMLElement | undefined;
 
     /**
      * If a new component is required and:
@@ -114,6 +115,7 @@ export abstract class LayoutManager extends EventEmitter {
      * {@link (LayoutManager:class).releaseComponentEvent} instead of registering a constructor callback
      */
     getComponentEvent: LayoutManager.GetComponentEventHandler | undefined;
+    createComponent: LayoutManager.CreateComponentHandler | undefined;
     releaseComponentEvent: LayoutManager.ReleaseComponentEventHandler | undefined;
 
     get container(): HTMLElement { return this._containerElement; }
@@ -209,6 +211,7 @@ export abstract class LayoutManager extends EventEmitter {
             }
             this._dragSources = [];
 
+            this.createComponent = undefined;
             this.getComponentEvent = undefined;
             this.releaseComponentEvent = undefined;
 
@@ -1784,6 +1787,8 @@ export namespace LayoutManager {
     export type ComponentConstructor = new(container: ComponentContainer, state: JsonValue | undefined) => ComponentItem.Component;
     export type ComponentFactoryFunction = (container: ComponentContainer, state: JsonValue | undefined) => ComponentItem.Component;
     export type GetComponentConstructorCallback = (this: void, config: ResolvedComponentItemConfig) => ComponentConstructor
+    export type CreateComponentHandler =
+        (this: void, item: ComponentItem, parentElement : HTMLElement, itemConfig: ResolvedComponentItemConfig) => HTMLElement;
     export type GetComponentEventHandler =
         (this: void, container: ComponentContainer, itemConfig: ResolvedComponentItemConfig) => ComponentItem.Component;
     export type ReleaseComponentEventHandler =


### PR DESCRIPTION
Add a hook to allow custom creation of content element that is *not* a child of the component element.
In this case the former's size, location and visibility have to be explicitly synchronized with the latter.
The advantage is that the content element is not moved around in the DOM, which avoids breaking iframe, sockets, etc.
This fixes issue #470 "avoid moving content in DOM tree".
