### PR TITLE
Disable user-select of drag handles.

### DIFF
--- a/src/scss/goldenlayout-base.scss
+++ b/src/scss/goldenlayout-base.scss
@@ -69,6 +69,7 @@ $height6: 15px; // Appears 1 time
       position: absolute;
       cursor: ns-resize;
       touch-action: none;
+      user-select: none;
     }
   }
 
@@ -81,6 +82,7 @@ $height6: 15px; // Appears 1 time
       position: absolute;
       cursor: ew-resize;
       touch-action: none;
+      user-select: none;
     }
   }
 }


### PR DESCRIPTION
I was experiencing a problem when using my mouse to resize a splitter, some text in the content box was getting selected.  It happens in the short moment before the mouse has moved far enough to trigger the resizing action.  Simply disabling user-select on it fixes it, and appears to fit alongside touch-action none, which was already existent.

Tested on Firefox and Chromium on Linux.  Problem did not appear on Chromium.  The fix functions on both.