### PR TITLE
fix: tabDropdown disable

### DIFF
--- a/apitest/predefined-layouts.ts
+++ b/apitest/predefined-layouts.ts
@@ -1,7 +1,7 @@
-import { EventComponent } from './event-component';
 import { ComponentItemConfig, ItemType, LayoutConfig, StackItemConfig } from '..';
 import { BooleanComponent } from './boolean-component';
 import { ColorComponent } from './color-component';
+import { EventComponent } from './event-component';
 import { TextComponent } from './text-component';
 
 export interface Layout {

--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -940,7 +940,7 @@ export namespace LayoutConfig {
         popin?: string;
         popout?: false | string;
         show?: false | Side;
-        tabDropdown?: string;
+        tabDropdown?: false | string;
     }
     // (undocumented)
     export namespace Header {
@@ -1439,7 +1439,7 @@ export namespace ResolvedLayoutConfig {
         // (undocumented)
         readonly show: false | Side;
         // (undocumented)
-        readonly tabDropdown: string;
+        readonly tabDropdown: false | string;
     }
     // (undocumented)
     export namespace Header {

--- a/src/ts/config/config.ts
+++ b/src/ts/config/config.ts
@@ -688,7 +688,7 @@ export namespace LayoutConfig {
          *
          * Default: 'additional tabs'
          */
-        tabDropdown?: string;
+        tabDropdown?: false | string;
     }
 
     export namespace Header {

--- a/src/ts/config/resolved-config.ts
+++ b/src/ts/config/resolved-config.ts
@@ -477,7 +477,7 @@ export namespace ResolvedLayoutConfig {
         readonly maximise: false | string;
         readonly minimise: string;
         readonly close: false | string;
-        readonly tabDropdown: string;
+        readonly tabDropdown: false | string;
     }
 
     export namespace Header {

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -140,7 +140,7 @@ export class Header extends EventEmitter {
             (x, y, dragListener, item) => this.handleTabInitiatedDragStartEvent(x, y, dragListener, item),
             () => this.processTabDropdownActiveChanged(),
         );
-        
+
         this._show = settings.show;
         this._popoutEnabled = settings.popoutEnabled;
         this._popoutLabel = settings.popoutLabel;
@@ -172,9 +172,11 @@ export class Header extends EventEmitter {
 
         this._tabControlOffset = this._layoutManager.layoutConfig.settings.tabControlOffset;
 
-        this._tabDropdownButton = new HeaderButton(this, this._tabDropdownLabel, DomConstants.ClassName.TabDropdown,
-            () => this._tabsContainer.showAdditionalTabsDropdown()
-        );
+        if (this._tabDropdownEnabled) {
+            this._tabDropdownButton = new HeaderButton(this, this._tabDropdownLabel, DomConstants.ClassName.TabDropdown,
+                () => this._tabsContainer.showAdditionalTabsDropdown()
+            );
+        }
 
         if (this._popoutEnabled) {
             this._popoutButton = new HeaderButton(this, this._popoutLabel, DomConstants.ClassName.Popout, () => this.handleButtonPopoutEvent());
@@ -386,7 +388,9 @@ export class Header extends EventEmitter {
 
     /** @internal */
     private processTabDropdownActiveChanged() {
-        setElementDisplayVisibility(this._tabDropdownButton.element, this._tabsContainer.dropdownActive);
+        if (this._tabDropdownButton !== undefined) {
+            setElementDisplayVisibility(this._tabDropdownButton.element, this._tabsContainer.dropdownActive);
+        }
     }
 
     /** @internal */


### PR DESCRIPTION
The tabDropdown property in configs were being ignored. This has now been fixed so that these can be used to prevent the Tab Dropdown control (down triangle) from appearing.