### PR TITLE
Fix popout URL generation in presence of hash

### DIFF
--- a/src/ts/controls/browser-popout.ts
+++ b/src/ts/controls/browser-popout.ts
@@ -285,16 +285,9 @@ export class BrowserPopout extends EventEmitter {
             throw new Error('Error while writing to localStorage ' + e.toString());
         }
 
-        const urlParts = document.location.href.split('?');
-
-        // URL doesn't contain GET-parameters
-        if (urlParts.length === 1) {
-            return urlParts[0] + '?gl-window=' + storageKey;
-
-            // URL contains GET-parameters
-        } else {
-            return document.location.href + '&gl-window=' + storageKey;
-        }
+        const url = new URL(location.href);
+        url.searchParams.set('gl-window', storageKey);
+        return url.toString();
     }
 
     /**

--- a/src/ts/utils/utils.ts
+++ b/src/ts/utils/utils.ts
@@ -1,12 +1,6 @@
 import { WidthAndHeight } from './types';
 
 /** @internal */
-export function getQueryStringParam(key: string): string | null {
-    let url = new URL(document.location.href);
-    return url.searchParams.get(key);
-}
-
-/** @internal */
 export function numberToPixels(value: number): string {
     return value.toString(10) + 'px';
 }

--- a/src/ts/utils/utils.ts
+++ b/src/ts/utils/utils.ts
@@ -2,8 +2,8 @@ import { WidthAndHeight } from './types';
 
 /** @internal */
 export function getQueryStringParam(key: string): string | null {
-    const matches = location.search.match(new RegExp(key + '=([^&]*)'));
-    return matches ? matches[1] : null;
+    let url = new URL(document.location.href);
+    return url.searchParams.get(key);
 }
 
 /** @internal */

--- a/src/ts/virtual-layout.ts
+++ b/src/ts/virtual-layout.ts
@@ -6,7 +6,6 @@ import { UnexpectedUndefinedError } from './errors/internal-error';
 import { LayoutManager } from './layout-manager';
 import { DomConstants } from './utils/dom-constants';
 import { I18nStringId, i18nStrings } from './utils/i18n-strings';
-import { getQueryStringParam } from './utils/utils';
 
 /** @public */
 export class VirtualLayout extends LayoutManager {
@@ -263,7 +262,7 @@ export namespace VirtualLayout {
         containerOrBindComponentEventHandler?: HTMLElement |  VirtualLayout.BindComponentEventHandler):
         LayoutManager.ConstructorParameters
     {
-        const windowConfigKey = subWindowChecked ? null : getQueryStringParam('gl-window');
+        const windowConfigKey = subWindowChecked ? null : new URL(document.location.href).searchParams.get('gl-window');
         subWindowChecked = true;
         const isSubWindow = windowConfigKey !== null;
 


### PR DESCRIPTION
Fixes #652

If a golden-layout popout was triggered from a website that
might use a hash value in its URL, the old code would append
the `gl-window` GET query parameter at the end of the URL,
which meant that the parameter would be part of the website's
hash string, breaking the popout's loading routine (and most
likely whatever code was relying on the hash string's content).