### PR TITLE
Fix drop item onto empty stack header

### DIFF
--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -730,6 +730,8 @@ export class Stack extends ComponentParentableItem {
                 y1: headerOffset.top + elementHeight - 20,
                 y2: headerOffset.top + elementHeight,
             };
+
+            this._dropIndex = 0;
         } else {
             let tabIndex = 0;
             // This indicates whether our cursor is exactly over a tab


### PR DESCRIPTION
Currently when dropping an item onto an empty stack header, UnexpectedUndefinedError('SODDI68990') is thrown because dropIndex is only set when tabsLength > 0. This fix sets dropIndex to 0 when tabsLength === 0.