### PR TITLE
Use 'draggable' attribute to indicate allowable drag targets.

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -376,7 +376,6 @@ export class DragSource {
     constructor(
     _layoutManager: LayoutManager,
     _element: HTMLElement,
-    _extraAllowableChildTargets: HTMLElement[],
     _componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig),
     _componentState: JsonValue | undefined,
     _title: string | undefined);

--- a/src/ts/controls/drag-source.ts
+++ b/src/ts/controls/drag-source.ts
@@ -28,8 +28,6 @@ export class DragSource {
         /** @internal */
         private readonly _element: HTMLElement,
         /** @internal */
-        private readonly _extraAllowableChildTargets: HTMLElement[],
-        /** @internal */
         private _componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig),
         /** @internal */
         private _componentState: JsonValue | undefined,
@@ -61,7 +59,7 @@ export class DragSource {
     private createDragListener() {
         this.removeDragListener();
 
-        this._dragListener = new DragListener(this._element, this._extraAllowableChildTargets);
+        this._dragListener = new DragListener(this._element);
         this._dragListener.on('dragStart', (x, y) => this.onDragStart(x, y));
         this._dragListener.on('dragStop', () => this.onDragStop());
     }

--- a/src/ts/controls/splitter.ts
+++ b/src/ts/controls/splitter.ts
@@ -19,6 +19,7 @@ export class Splitter {
         this._element.classList.add(DomConstants.ClassName.Splitter);
         const dragHandleElement = document.createElement('div');
         dragHandleElement.classList.add(DomConstants.ClassName.DragHandle);
+        this._element.setAttribute('draggable', 'yes');
 
         const handleExcessSize = this._grabSize - this._size;
         const handleExcessPos = handleExcessSize / 2;
@@ -37,7 +38,7 @@ export class Splitter {
 
         this._element.appendChild(dragHandleElement);
 
-        this._dragListener = new DragListener(this._element, [dragHandleElement]);
+        this._dragListener = new DragListener(this._element);
     }
 
     destroy(): void {

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -76,6 +76,8 @@ export class Tab {
         this._titleElement.classList.add(DomConstants.ClassName.Title);
         this._closeElement = document.createElement('div'); 
         this._closeElement.classList.add(DomConstants.ClassName.CloseTab);
+        this._element.setAttribute('draggable', 'yes');
+        this._closeElement.setAttribute('draggable', 'no');
         this._element.appendChild(this._titleElement);
         this._element.appendChild(this._closeElement);
 
@@ -265,7 +267,7 @@ export class Tab {
 
     /** @internal */
     private enableReorder() {
-        this._dragListener = new DragListener(this._element, [this._titleElement]);
+        this._dragListener = new DragListener(this._element);
         this._dragListener.on('dragStart', this._dragStartListener);
         this._componentItem.on('destroy', this._contentItemDestroyListener);
     }

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -899,7 +899,7 @@ export abstract class LayoutManager extends EventEmitter {
         componentState?: JsonValue,
         title?: string,
     ): DragSource {
-        const dragSource = new DragSource(this, element, [], componentTypeOrItemConfigCallback, componentState, title);
+        const dragSource = new DragSource(this, element, componentTypeOrItemConfigCallback, componentState, title);
         this._dragSources.push(dragSource);
 
         return dragSource;

--- a/test/specs/drag-tests.ts
+++ b/test/specs/drag-tests.ts
@@ -42,6 +42,7 @@ describe('drag source', function() {
 	function createDragSource(deferred: boolean): void {
 		dragSourceElement = document.createElement('div');
 		dragSourceElement.id = 'dragSrc';
+		dragSourceElement.setAttribute('draggable', 'yes');
 		document.body.appendChild(dragSourceElement);
 
 		const componentType = TestTools.TEST_COMPONENT_NAME;


### PR DESCRIPTION
This follows the conventions of the HTML5 drag-and-drop API, and replaces the `_extraAllowableChildTargets` property.

Using the `draggable` attribute is in addition to being forward-looking to future use of the HTML5 drag-and-drop API, it is also cleaner and more flexible. Specifically, it enables "long titles" (issue #709) because the latter may include user-provided sub-elements which would be messy to deal with using `_extraAllowableChildTargets`. PR #718 includes this PR (more-or-less); if this is approved I will clean up #718 accordingly.