### PR TITLE
fix virtual ZIndex not correctly initialised

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -101,6 +101,10 @@ export class ComponentContainer extends EventEmitter {
     // (undocumented)
     get parent(): ComponentItem;
     replaceComponent(itemConfig: ComponentItemConfig): void;
+    // (undocumented)
+    setBaseLogicalZIndex(): void;
+    // (undocumented)
+    setLogicalZIndex(logicalZIndex: LogicalZIndex): void;
     // @internal
     setSize(width: number, height: number): boolean;
     // @internal
@@ -1188,6 +1192,13 @@ export namespace LogicalZIndex {
     const // (undocumented)
     stackMaximised = "stackMaximised";
 }
+
+// @public (undocumented)
+export const LogicalZIndexToDefaultMap: {
+    base: string;
+    drag: string;
+    stackMaximised: string;
+};
 
 // @public (undocumented)
 export class PopoutBlockedError extends ExternalError {

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -180,6 +180,7 @@ export class Stack extends ComponentParentableItem {
                     } else {
                         this._header.createTab(contentItem, i);
                         contentItem.hide();
+                        contentItem.container.setBaseLogicalZIndex();
                     }
                 }
 
@@ -297,6 +298,7 @@ export class Stack extends ComponentParentableItem {
             this.setActiveComponentItem(contentItem, focus);
             this._header.updateTabSizes();
             this.updateSize();
+            contentItem.container.setBaseLogicalZIndex();
             this._header.updateClosability();
             this.emitStateChangedEvent();
             return index;

--- a/src/ts/utils/types.ts
+++ b/src/ts/utils/types.ts
@@ -1,3 +1,5 @@
+import { StyleConstants } from './style-constants';
+
 /** @internal */
 export type WidthOrHeightPropertyName = 'width' | 'height';
 
@@ -36,6 +38,13 @@ export namespace LogicalZIndex {
     export const base = 'base';
     export const drag = 'drag';
     export const stackMaximised = 'stackMaximised';
+}
+
+/** @public */
+export const LogicalZIndexToDefaultMap = {
+    base: StyleConstants.defaultComponentBaseZIndex,
+    drag: StyleConstants.defaultComponentDragZIndex,
+    stackMaximised: StyleConstants.defaultComponentDragZIndex,
 }
 
 /** @internal */


### PR DESCRIPTION
Z Index change required event is not initially fired for components when a layout is first loaded.  This has not been a problem as the value `auto` is initially suggested which is the default.  However for consistency, this event should be fired so that applications can initially explicitly set the Z Index value for components.