### PR TITLE
Optimise update size

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -101,6 +101,10 @@ export class ComponentContainer extends EventEmitter {
     // (undocumented)
     get parent(): ComponentItem;
     replaceComponent(itemConfig: ComponentItemConfig): void;
+    // (undocumented)
+    setBaseLogicalZIndex(): void;
+    // (undocumented)
+    setLogicalZIndex(logicalZIndex: LogicalZIndex): void;
     // @internal
     setSize(width: number, height: number): boolean;
     // @internal
@@ -1188,6 +1192,13 @@ export namespace LogicalZIndex {
     const // (undocumented)
     stackMaximised = "stackMaximised";
 }
+
+// @public (undocumented)
+export const LogicalZIndexToDefaultMap: {
+    base: string;
+    drag: string;
+    stackMaximised: string;
+};
 
 // @public (undocumented)
 export class PopoutBlockedError extends ExternalError {

--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -235,7 +235,7 @@ export class ComponentItem extends ContentItem {
     // (undocumented)
     toConfig(): ResolvedComponentItemConfig;
     // @internal (undocumented)
-    updateSize(): void;
+    updateSize(force: boolean): void;
 }
 
 // @public (undocumented)
@@ -356,9 +356,9 @@ export abstract class ContentItem extends EventEmitter {
     // (undocumented)
     get type(): ItemType;
     // @internal (undocumented)
-    protected updateContentItemsSize(): void;
+    protected updateContentItemsSize(force: boolean): void;
     // @internal
-    abstract updateSize(): void;
+    abstract updateSize(force: boolean): void;
     // @internal (undocumented)
     width: number;
 }
@@ -1118,7 +1118,7 @@ export abstract class LayoutManager extends EventEmitter {
     abstract unbindComponent(container: ComponentContainer, virtual: boolean, component: ComponentContainer.Component | undefined): void;
     // @deprecated
     unminifyConfig(config: ResolvedLayoutConfig): ResolvedLayoutConfig;
-    updateRootSize(): void;
+    updateRootSize(force?: boolean): void;
     // @deprecated (undocumented)
     updateSize(width: number, height: number): void;
     // @internal (undocumented)
@@ -1636,7 +1636,7 @@ export class RowOrColumn extends ContentItem {
     protected setParent(parent: ContentItem): void;
     // (undocumented)
     toConfig(): ResolvedRowOrColumnItemConfig;
-    updateSize(): void;
+    updateSize(force: boolean): void;
 }
 
 // @public (undocumented)
@@ -1752,7 +1752,7 @@ export class Stack extends ComponentParentableItem {
     toConfig(): ResolvedStackItemConfig;
     toggleMaximise(): void;
     // @internal (undocumented)
-    updateSize(): void;
+    updateSize(force: boolean): void;
 }
 
 // @public (undocumented)

--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -1015,6 +1015,8 @@ export abstract class LayoutManager extends EventEmitter {
     // (undocumented)
     beforeVirtualRectingEvent: LayoutManager.BeforeVirtualRectingEvent | undefined;
     // @internal (undocumented)
+    beginSizeInvalidation(): void;
+    // @internal (undocumented)
     beginVirtualSizedContainerAdding(): void;
     // @internal (undocumented)
     abstract bindComponent(container: ComponentContainer, itemConfig: ResolvedComponentItemConfig): ComponentContainer.BindableComponent;
@@ -1046,6 +1048,8 @@ export abstract class LayoutManager extends EventEmitter {
     //
     // @internal (undocumented)
     get dropTargetIndicator(): DropTargetIndicator | null;
+    // @internal (undocumented)
+    endSizeInvalidation(): void;
     // @internal (undocumented)
     endVirtualSizedContainerAdding(): void;
     get eventHub(): EventHub;

--- a/src/ts/container/component-container.ts
+++ b/src/ts/container/component-container.ts
@@ -189,7 +189,7 @@ export class ComponentContainer extends EventEmitter {
                         }
                     }
 
-                    ancestorItem.updateSize();
+                    ancestorItem.updateSize(false);
 
                     return true;
                 }

--- a/src/ts/items/component-item.ts
+++ b/src/ts/items/component-item.ts
@@ -143,13 +143,13 @@ export class ComponentItem extends ContentItem {
     }
 
     /** @internal */
-    override updateSize(): void {
-        this.updateNodeSize();
+    override updateSize(force: boolean): void {
+        this.updateNodeSize(force);
     }
 
     /** @internal */
     override init(): void {
-        this.updateNodeSize();
+        this.updateNodeSize(false);
 
         super.init();
         this._container.emit('open');
@@ -233,12 +233,12 @@ export class ComponentItem extends ContentItem {
     }
 
     /** @internal */
-    private updateNodeSize(): void {
+    private updateNodeSize(force: boolean): void {
         if (this.element.style.display !== 'none') {
             // Do not update size of hidden components to prevent unwanted reflows
 
             const { width, height } = getElementWidthAndHeight(this.element);
-            this._container.setSizeToNodeSize(width, height, false);
+            this._container.setSizeToNodeSize(width, height, force);
         }
     }
 }

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -291,14 +291,19 @@ export abstract class ContentItem extends EventEmitter {
 
     /** @internal */
     show(): void {
-        // Not sure why showAllActiveContentItems() was called. GoldenLayout seems to work fine without it.  Left commented code
-        // in source in case a reason for it becomes apparent.
-        // this.layoutManager.showAllActiveContentItems();
-        setElementDisplayVisibility(this._element, true);
-        this.layoutManager.updateSizeFromContainer();
+        this.layoutManager.beginSizeInvalidation();
+        try {
+            // Not sure why showAllActiveContentItems() was called. GoldenLayout seems to work fine without it.  Left commented code
+            // in source in case a reason for it becomes apparent.
+            // this.layoutManager.showAllActiveContentItems();
+            setElementDisplayVisibility(this._element, true);
+            // this.layoutManager.updateSizeFromContainer();
 
-        for (let i = 0; i < this._contentItems.length; i++) {
-            this._contentItems[i].show();
+            for (let i = 0; i < this._contentItems.length; i++) {
+                this._contentItems[i].show();
+            }
+        } finally {
+            this.layoutManager.endSizeInvalidation();
         }
     }
 
@@ -374,8 +379,13 @@ export abstract class ContentItem extends EventEmitter {
 
     /** @internal */
     protected hide(): void {
-        setElementDisplayVisibility(this._element, false);
-        this.layoutManager.updateSizeFromContainer();
+        this.layoutManager.beginSizeInvalidation();
+        try {
+            setElementDisplayVisibility(this._element, false);
+            // this.layoutManager.updateSizeFromContainer();
+        } finally {
+            this.layoutManager.endSizeInvalidation();
+        }
     }
 
     /** @internal */

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -109,9 +109,13 @@ export abstract class ContentItem extends EventEmitter {
 
     /**
      * Updaters the size of the component and its children, called recursively
+     * @param force - In some cases the size is not updated if it has not changed. In this case, events
+     * (such as ComponentContainer.virtualRectingRequiredEvent) are not fired. Setting force to true, ensures the size is updated regardless, and
+     * the respective events are fired. This is sometimes necessary when a component's size has not changed but it has become visible, and the
+     * relevant events need to be fired.
      * @internal
      */
-    abstract updateSize(): void;
+    abstract updateSize(force: boolean): void;
 
     /**
      * Removes a child node (and its children) from the tree
@@ -148,7 +152,7 @@ export abstract class ContentItem extends EventEmitter {
          * If this node still contains other content items, adjust their size
          */
         if (this._contentItems.length > 0) {
-            this.updateSize();
+            this.updateSize(false);
         } else {
             /**
              * If this was the last content item, remove this node as well
@@ -231,7 +235,7 @@ export abstract class ContentItem extends EventEmitter {
                     newChild.init();
                 }
 
-                this.updateSize();
+                this.updateSize(false);
             }
         }
     }
@@ -389,9 +393,9 @@ export abstract class ContentItem extends EventEmitter {
     }
 
     /** @internal */
-    protected updateContentItemsSize(): void {
+    protected updateContentItemsSize(force: boolean): void {
         for (let i = 0; i < this._contentItems.length; i++) {
-            this._contentItems[i].updateSize();
+            this._contentItems[i].updateSize(force);
         }
     }
 

--- a/src/ts/items/ground-item.ts
+++ b/src/ts/items/ground-item.ts
@@ -142,7 +142,7 @@ export class GroundItem extends ComponentParentableItem {
             this._childElementContainer.appendChild(contentItem.element);
             index = super.addChild(contentItem, index);
 
-            this.updateSize();
+            this.updateSize(false);
             this.emitBaseBubblingEvent('stateChanged');
 
             return index;
@@ -169,7 +169,7 @@ export class GroundItem extends ComponentParentableItem {
     /** @internal */
     setSize(width: number, height: number): void {
         if (width === undefined || height === undefined) {
-            this.updateSize(); // For backwards compatibility with v1.x API
+            this.updateSize(false); // For backwards compatibility with v1.x API
         } else {
             setElementWidth(this.element, width);
             setElementHeight(this.element, height);
@@ -180,7 +180,7 @@ export class GroundItem extends ComponentParentableItem {
                 setElementHeight(this.contentItems[0].element, height);
             }
 
-            this.updateContentItemsSize();
+            this.updateContentItemsSize(false);
         }
     }
 
@@ -188,11 +188,11 @@ export class GroundItem extends ComponentParentableItem {
      * Adds a Root ContentItem.
      * Internal only.  To replace Root ContentItem with API, use {@link (LayoutManager:class).updateRootSize}
      */
-    override updateSize(): void {
+    override updateSize(force: boolean): void {
         this.layoutManager.beginVirtualSizedContainerAdding();
         try {
             this.updateNodeSize();
-            this.updateContentItemsSize();
+            this.updateContentItemsSize(force);
         } finally {
             this.layoutManager.endVirtualSizedContainerAdding();
         }
@@ -268,13 +268,13 @@ export class GroundItem extends ComponentParentableItem {
                 rowOrColumn.addChild(column, insertBefore ? undefined : 0, true);
                 column[dimension] = 50;
                 contentItem[dimension] = 50;
-                rowOrColumn.updateSize();
+                rowOrColumn.updateSize(false);
             } else {
                 const sibling = column.contentItems[insertBefore ? 0 : column.contentItems.length - 1]
                 column.addChild(contentItem, insertBefore ? 0 : undefined, true);
                 sibling[dimension] *= 0.5;
                 contentItem[dimension] = sibling[dimension];
-                column.updateSize();
+                column.updateSize(false);
             }
         }
     }

--- a/src/ts/items/row-or-column.ts
+++ b/src/ts/items/row-or-column.ts
@@ -162,7 +162,7 @@ export class RowOrColumn extends ContentItem {
             }
         }
 
-        this.updateSize();
+        this.updateSize(false);
         this.emitBaseBubblingEvent('stateChanged');
 
         return index;
@@ -199,7 +199,7 @@ export class RowOrColumn extends ContentItem {
             this.contentItems.length = 0;
             this._rowOrColumnParent.replaceChild(this, childItem, true);
         } else {
-            this.updateSize();
+            this.updateSize(false);
             this.emitBaseBubblingEvent('stateChanged');
         }
     }
@@ -211,18 +211,18 @@ export class RowOrColumn extends ContentItem {
         const size = oldChild[this._dimension];
         super.replaceChild(oldChild, newChild);
         newChild[this._dimension] = size;
-        this.updateSize();
+        this.updateSize(false);
         this.emitBaseBubblingEvent('stateChanged');
     }
 
     /**
      * Called whenever the dimensions of this item or one of its parents change
      */
-    override updateSize(): void {
+    override updateSize(force: boolean): void {
         this.layoutManager.beginVirtualSizedContainerAdding();
         try {
             this.updateNodeSize();
-            this.updateContentItemsSize();
+            this.updateContentItemsSize(force);
         } finally {
             this.layoutManager.endVirtualSizedContainerAdding();
         }
@@ -627,7 +627,7 @@ export class RowOrColumn extends ContentItem {
             splitter.element.style.top = numberToPixels(0);
             splitter.element.style.left = numberToPixels(0);
 
-            globalThis.requestAnimationFrame(() => this.updateSize());
+            globalThis.requestAnimationFrame(() => this.updateSize(false));
         }
     }
 }

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -180,6 +180,7 @@ export class Stack extends ComponentParentableItem {
                     } else {
                         this._header.createTab(contentItem, i);
                         contentItem.hide();
+                        contentItem.container.setBaseLogicalZIndex();
                     }
                 }
 
@@ -297,6 +298,7 @@ export class Stack extends ComponentParentableItem {
             this.setActiveComponentItem(contentItem, focus);
             this._header.updateTabSizes();
             this.updateSize();
+            contentItem.container.setBaseLogicalZIndex();
             this._header.updateClosability();
             this.emitStateChangedEvent();
             return index;

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -145,11 +145,11 @@ export class Stack extends ComponentParentableItem {
     }
 
     /** @internal */
-    override updateSize(): void {
+    override updateSize(force: boolean): void {
         this.layoutManager.beginVirtualSizedContainerAdding();
         try {
             this.updateNodeSize();
-            this.updateContentItemsSize();
+            this.updateContentItemsSize(force);
         } finally {
             this.layoutManager.endVirtualSizedContainerAdding();
         }
@@ -303,7 +303,7 @@ export class Stack extends ComponentParentableItem {
             this._header.createTab(contentItem, index);
             this.setActiveComponentItem(contentItem, focus);
             this._header.updateTabSizes();
-            this.updateSize();
+            this.updateSize(false);
             contentItem.container.setBaseLogicalZIndex();
             this._header.updateClosability();
             this.emitStateChangedEvent();
@@ -514,7 +514,7 @@ export class Stack extends ComponentParentableItem {
             this.stackParent.addChild(contentItem, insertBefore ? index : index + 1, true);
             this[dimension] *= 0.5;
             contentItem[dimension] = this[dimension];
-            this.stackParent.updateSize();
+            this.stackParent.updateSize(false);
             /*
              * This handles items that are dropped on top or bottom of a row or left / right of a column. We need
              * to create the appropriate contentItem for them to live in
@@ -530,7 +530,7 @@ export class Stack extends ComponentParentableItem {
 
             this[dimension] = 50;
             contentItem[dimension] = 50;
-            rowOrColumn.updateSize();
+            rowOrColumn.updateSize(false);
         }
     }
 
@@ -826,7 +826,7 @@ export class Stack extends ComponentParentableItem {
         //    // move the header behind the content.
         //    this.element.appendChild(this._header.element);
         //}
-        this.updateSize();
+        this.updateSize(false);
     }
 
     /** @internal */

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -208,12 +208,18 @@ export class Stack extends ComponentParentableItem {
             if (this.contentItems.indexOf(componentItem) === -1) {
                 throw new Error('componentItem is not a child of this stack');
             } else {
-                if (this._activeComponentItem !== undefined) {
-                    this._activeComponentItem.hide();
+                this.layoutManager.beginSizeInvalidation();
+                try {
+                    if (this._activeComponentItem !== undefined) {
+                        this._activeComponentItem.hide();
+                    }
+                    this._activeComponentItem = componentItem;
+                    this._header.processActiveComponentChanged(componentItem);
+                    componentItem.show();
+                } finally {
+                    this.layoutManager.endSizeInvalidation();
                 }
-                this._activeComponentItem = componentItem;
-                this._header.processActiveComponentChanged(componentItem);
-                componentItem.show();
+
                 this.emit('activeContentItemChanged', componentItem);
                 this.layoutManager.emit('activeContentItemChanged', componentItem);
                 this.emitStateChangedEvent();

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -623,7 +623,7 @@ export abstract class LayoutManager extends EventEmitter {
                     const { width, height } = getElementWidthAndHeight(this._containerElement);
                     setElementWidth(this._maximisedStack.element, width);
                     setElementHeight(this._maximisedStack.element, height);
-                    this._maximisedStack.updateSize();
+                    this._maximisedStack.updateSize(false);
                 }
 
                 this.adjustColumnsResponsive();
@@ -651,12 +651,16 @@ export abstract class LayoutManager extends EventEmitter {
 
     /**
      * Update the size of the root ContentItem.  This will update the size of all contentItems in the tree
+     * @param force - In some cases the size is not updated if it has not changed. In this case, events
+     * (such as ComponentContainer.virtualRectingRequiredEvent) are not fired. Setting force to true, ensures the size is updated regardless, and
+     * the respective events are fired. This is sometimes necessary when a component's size has not changed but it has become visible, and the
+     * relevant events need to be fired.
      */
-    updateRootSize(): void {
+    updateRootSize(force = false): void {
         if (this._groundItem === undefined) {
             throw new UnexpectedUndefinedError('LMURS28881');
         } else {
-            this._groundItem.updateSize();
+            this._groundItem.updateSize(force);
         }
     }
 
@@ -1241,7 +1245,7 @@ export abstract class LayoutManager extends EventEmitter {
             const { width, height } = getElementWidthAndHeight(this._containerElement);
             setElementWidth(stack.element, width);
             setElementHeight(stack.element, height);
-            stack.updateSize();
+            stack.updateSize(true);
             stack.focusActiveContentItem();
             this._maximisedStack.emit('maximised');
             this.emit('stateChanged');
@@ -1260,7 +1264,7 @@ export abstract class LayoutManager extends EventEmitter {
                 stack.element.classList.remove(DomConstants.ClassName.Maximised);
                 this._maximisePlaceholder.insertAdjacentElement('afterend', stack.element);
                 this._maximisePlaceholder.remove();
-                stack.parent.updateSize();
+                this.updateRootSize(true);
                 this._maximisedStack = undefined;
                 stack.off('beforeItemDestroyed', this._maximisedStackBeforeDestroyedListener);
                 stack.emit('minimised');

--- a/src/ts/utils/types.ts
+++ b/src/ts/utils/types.ts
@@ -1,3 +1,5 @@
+import { StyleConstants } from './style-constants';
+
 /** @internal */
 export type WidthOrHeightPropertyName = 'width' | 'height';
 
@@ -36,6 +38,13 @@ export namespace LogicalZIndex {
     export const base = 'base';
     export const drag = 'drag';
     export const stackMaximised = 'stackMaximised';
+}
+
+/** @public */
+export const LogicalZIndexToDefaultMap = {
+    base: StyleConstants.defaultComponentBaseZIndex,
+    drag: StyleConstants.defaultComponentDragZIndex,
+    stackMaximised: StyleConstants.defaultComponentDragZIndex,
 }
 
 /** @internal */


### PR DESCRIPTION
`Layout.updateSizeFromContainer()` is called multiple times when focus changes to a different component (ie a tab is clicked).  This can cause a perceptible delay when clicking the tabs in a layout with many components. This PR optimises this by calling `Layout.updateSizeFromContainer()` only once after all the necessary visibility changes.

Note that a future PR optimising Tab behaviour as suggested in [issue #736](https://github.com/golden-layout/golden-layout/issues/736#issuecomment-960287054) will also improve this.