### PR TITLE
custimizable TitleRenderer callback for tab titles

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -376,7 +376,6 @@ export class DragSource {
     constructor(
     _layoutManager: LayoutManager,
     _element: HTMLElement,
-    _extraAllowableChildTargets: HTMLElement[],
     _componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig),
     _componentState: JsonValue | undefined,
     _title: string | undefined);

--- a/src/less/goldenlayout-base.less
+++ b/src/less/goldenlayout-base.less
@@ -3,7 +3,7 @@
 // can also be developed using SCSS.
 // All changes to base style should be done in goldenlayout-base.less.
 // Do NOT make changes directly in goldenlayout-base.scss.  goldenlayout-base.scss should only be updated by
-// running the npm script "update-scss"
+// running the npm script "update:scss"
 // Make sure that less code in goldenlayout.base.less can be correctly correctly converted to scss with less2sass (ie keep it basic)
 
 // Width variables (appears count calculates by raw css)
@@ -101,6 +101,7 @@
   // Pane controls (popout, maximize, minimize, close)
   .lm_controls {
     position: absolute;
+    top: 0px;
     right: 3px;
     display: flex;
 
@@ -114,8 +115,14 @@
   }
 
   .lm_tabs {
-    position: absolute;
     display: flex;
+  }
+
+  .lm_title {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre;
   }
 
   // Single Tab container. A single Tab is set for each pane, a group of Tabs are contained in ".lm_header"
@@ -143,12 +150,6 @@
         top: 0;
         right: -2px;
       }
-    }
-
-    .lm_title {
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     // Close Tab Icon
@@ -331,6 +332,10 @@
     right: 0;
     z-index: 5;
     overflow: hidden;
+    .lm_title {
+        display: block;
+        padding: 1px;
+    }
 
     .lm_tab {
       clear: both;

--- a/src/scss/goldenlayout-base.scss
+++ b/src/scss/goldenlayout-base.scss
@@ -3,7 +3,7 @@
 // can also be developed using SCSS.
 // All changes to base style should be done in goldenlayout-base.scss.
 // Do NOT make changes directly in goldenlayout-base.scss.  goldenlayout-base.scss should only be updated by
-// running the npm script "update-scss"
+// running the npm script "update:scss"
 // Make sure that less code in goldenlayout.base.scss can be correctly correctly converted to scss with less2sass (ie keep it basic)
 
 // Width variables (appears count calculates by raw css)
@@ -101,6 +101,7 @@ $height6: 15px; // Appears 1 time
   // Pane controls (popout, maximize, minimize, close)
   .lm_controls {
     position: absolute;
+    top: 0px;
     right: 3px;
     display: flex;
 
@@ -114,8 +115,14 @@ $height6: 15px; // Appears 1 time
   }
 
   .lm_tabs {
-    position: absolute;
     display: flex;
+  }
+
+  .lm_title {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre;
   }
 
   // Single Tab container. A single Tab is set for each pane, a group of Tabs are contained in ".lm_header"
@@ -143,12 +150,6 @@ $height6: 15px; // Appears 1 time
         top: 0;
         right: -2px;
       }
-    }
-
-    .lm_title {
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     // Close Tab Icon
@@ -331,6 +332,10 @@ $height6: 15px; // Appears 1 time
     right: 0;
     z-index: 5;
     overflow: hidden;
+    .lm_title {
+        display: block;
+        padding: 1px;
+    }
 
     .lm_tab {
       clear: both;

--- a/src/ts/container/component-container.ts
+++ b/src/ts/container/component-container.ts
@@ -279,6 +279,10 @@ export class ComponentContainer extends EventEmitter {
         this._parent.setTitle(title);
     }
 
+    setTitleRenderer(renderer: Tab.TitleRenderer | undefined): void {
+        this._parent.setTitleRenderer(renderer);
+    }
+
     /** @internal */
     setTab(tab: Tab): void {
         this._tab = tab;

--- a/src/ts/controls/drag-source.ts
+++ b/src/ts/controls/drag-source.ts
@@ -28,8 +28,6 @@ export class DragSource {
         /** @internal */
         private readonly _element: HTMLElement,
         /** @internal */
-        private readonly _extraAllowableChildTargets: HTMLElement[],
-        /** @internal */
         private _componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig),
         /** @internal */
         private _componentState: JsonValue | undefined,
@@ -61,7 +59,7 @@ export class DragSource {
     private createDragListener() {
         this.removeDragListener();
 
-        this._dragListener = new DragListener(this._element, this._extraAllowableChildTargets);
+        this._dragListener = new DragListener(this._element);
         this._dragListener.on('dragStart', (x, y) => this.onDragStart(x, y));
         this._dragListener.on('dragStop', () => this.onDragStop());
     }

--- a/src/ts/controls/splitter.ts
+++ b/src/ts/controls/splitter.ts
@@ -19,6 +19,7 @@ export class Splitter {
         this._element.classList.add(DomConstants.ClassName.Splitter);
         const dragHandleElement = document.createElement('div');
         dragHandleElement.classList.add(DomConstants.ClassName.DragHandle);
+        this._element.setAttribute('draggable', 'yes');
 
         const handleExcessSize = this._grabSize - this._size;
         const handleExcessPos = handleExcessSize / 2;
@@ -37,7 +38,7 @@ export class Splitter {
 
         this._element.appendChild(dragHandleElement);
 
-        this._dragListener = new DragListener(this._element, [dragHandleElement]);
+        this._dragListener = new DragListener(this._element);
     }
 
     destroy(): void {

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -76,6 +76,8 @@ export class Tab {
         this._titleElement.classList.add(DomConstants.ClassName.Title);
         this._closeElement = document.createElement('div'); 
         this._closeElement.classList.add(DomConstants.ClassName.CloseTab);
+        this._element.setAttribute('draggable', 'yes');
+        this._closeElement.setAttribute('draggable', 'no');
         this._element.appendChild(this._titleElement);
         this._element.appendChild(this._closeElement);
 
@@ -265,7 +267,7 @@ export class Tab {
 
     /** @internal */
     private enableReorder() {
-        this._dragListener = new DragListener(this._element, [this._titleElement]);
+        this._dragListener = new DragListener(this._element);
         this._dragListener.on('dragStart', this._dragStartListener);
         this._componentItem.on('destroy', this._contentItemDestroyListener);
     }

--- a/src/ts/items/component-item.ts
+++ b/src/ts/items/component-item.ts
@@ -24,6 +24,8 @@ export class ComponentItem extends ContentItem {
     /** @internal */
     private _tab: Tab;
     /** @internal */
+    private _titleRenderer: Tab.TitleRenderer | undefined;
+    /** @internal */
     private _focused = false;
 
     /** @internal @deprecated use {@link (ComponentItem:class).componentType} */
@@ -38,6 +40,7 @@ export class ComponentItem extends ContentItem {
 
     get headerConfig(): ResolvedHeaderedItemConfig.Header | undefined { return this._headerConfig; }
     get title(): string { return this._title; }
+    get titleRenderer(): Tab.TitleRenderer | undefined { return this._titleRenderer; }
     get tab(): Tab { return this._tab; }
     get focused(): boolean { return this._focused; }
 
@@ -166,6 +169,12 @@ export class ComponentItem extends ContentItem {
     setTitle(title: string): void {
         this._title = title;
         this.emit('titleChanged', title);
+        this.emit('stateChanged');
+    }
+
+    setTitleRenderer(renderer: Tab.TitleRenderer | undefined): void {
+        this._titleRenderer = renderer;
+        this.emit('titleChanged', this._title);
         this.emit('stateChanged');
     }
 

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -45,7 +45,7 @@ export class Stack extends ComponentParentableItem {
     private _initialActiveItemIndex: number;
 
     /** @internal */
-    private _resizeListener = () => this.handleResize();
+    private _resizeListener = () => this.updateTabSizes();
     /** @internal */
     private _maximisedListener = () => this.handleMaximised();
     /** @internal */
@@ -186,7 +186,7 @@ export class Stack extends ComponentParentableItem {
 
                 this.setActiveComponentItem(contentItems[this._initialActiveItemIndex] as ComponentItem, false);
 
-                this._header.updateTabSizes();
+                this.updateTabSizes();
             }
         }
 
@@ -839,9 +839,9 @@ export class Stack extends ComponentParentableItem {
         }
     }
 
-    /** @internal */
-    private handleResize() {
-        this._header.updateTabSizes()
+    updateTabSizes(): void {
+        if (this._header)
+            this._header.updateTabSizes();
     }
 
     /** @internal */

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -1734,6 +1734,13 @@ export namespace LayoutManager {
     }
 
     /** @public */
+    export enum RenderFlags {
+        DropdownActive = 1,
+        InDropdownManu = 2,
+        IsActiveTab = 4,
+    };
+
+    /** @public */
     export namespace LocationSelector {
         export const enum TypeId {
             /** Stack with focused Item. Index specifies offset from index of focused item (eg 1 is the position after focused item) */

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -899,7 +899,7 @@ export abstract class LayoutManager extends EventEmitter {
         componentState?: JsonValue,
         title?: string,
     ): DragSource {
-        const dragSource = new DragSource(this, element, [], componentTypeOrItemConfigCallback, componentState, title);
+        const dragSource = new DragSource(this, element, componentTypeOrItemConfigCallback, componentState, title);
         this._dragSources.push(dragSource);
 
         return dragSource;

--- a/src/ts/utils/drag-listener.ts
+++ b/src/ts/utils/drag-listener.ts
@@ -63,20 +63,18 @@ export class DragListener extends EventEmitter {
         this.processDragStop(undefined);
     }
 
-    private allowableTarget(target: EventTarget | null): boolean {
-        for (; target instanceof HTMLElement; target = target.parentNode) {
+    private onPointerDown(oEvent: PointerEvent) {
+        for (let target = oEvent.target; ; target = target.parentNode) {
+            if (! (target instanceof HTMLElement))
+                return;
             const draggable = target.getAttribute('draggable');
             if (draggable === 'yes')
-                return true;
-            if (draggable !== null)
                 break;
+            if (draggable !== null)
+                return;
         }
-        return false;
-    }
 
-    private onPointerDown(oEvent: PointerEvent) {
-        if (this.allowableTarget(oEvent.target))
-            this.processPointerDown(this.getPointerCoordinates(oEvent));
+        this.processPointerDown(this.getPointerCoordinates(oEvent));
     }
 
     private processPointerDown(coordinates: DragListener.PointerCoordinates) {

--- a/test/specs/drag-tests.ts
+++ b/test/specs/drag-tests.ts
@@ -42,6 +42,7 @@ describe('drag source', function() {
 	function createDragSource(deferred: boolean): void {
 		dragSourceElement = document.createElement('div');
 		dragSourceElement.id = 'dragSrc';
+		dragSourceElement.setAttribute('draggable', 'yes');
 		document.body.appendChild(dragSourceElement);
 
 		const componentType = TestTools.TEST_COMPONENT_NAME;


### PR DESCRIPTION
This implements a customization hook that allows an application to customize how tab titles are drawn. It is based on [this comment](https://github.com/golden-layout/golden-layout/issues/736#issuecomment-1003448150). It provides part of the needed functionality for issue #736 - it allows customizing the title part of an individual tab, but does not provide any mechanism to further customize headers,   (That is a problem for another day, and can build on this PR.)

 The hook is a function that has type `TitleRenderer` and is registered by `container.setTitleRenderer`. As an example of how it is used in DomTerm:

    r.setTitleRenderer((container, el, width, flags) => {
       if (wname &&
            ((flags & Tab.RenderFlags.InDropdownMenu) ||
             ! (flags & Tab.RenderFlags.DropdownActive))) {
            el.innerHTML =
                DomTerm.escapeText(title)+'<span class="domterm-windowname"> '+DomTerm.escapeText(wname)+'</span>';
        } else {
            el.innerText = title;
        }
    });

The functions takes four argument:
* The container that corresponds to the Tab.
* The `lm_title` element to "paint".  The function is responsible for reusing or removing existing children.  This allows reuse of title components, which may sometimes be a worthwhile optimization.  Existing children are automatically replaced by `innerHTML` or `innerText`, which is while the example doesn't do it explicitly.
* The available width for the title.  This is a hint which the function can ignore, but in that case the caller can enforce it.
* A set of flags: `DropdownActive` if there is a drop-down menu in the header; `InDropdownMenu` if we're creating the drop-down menu; `IsActiveTab` if the tab is active.

This is working acceptably for me in DomTerm, but should be considered a work-in-process.  Most specifically, the `tryUpdateTabSizes` function in `tabs-container.ts` needs some polishing. For example, if space is tight, we could and should remove the close button for inactive tabs. It also needs some work to truncate a tab title if necessary.

This builds on PR #737.  I've made some progress some progress is using HTML drag-and-drop (issue #680): I can drag and sort-of-drop a component from one top-level window to another. However, I'd like to move forward on customizing titles so I don't have too many changes at once - but regardless using the `draggable` attribute seems a good step.