### PR TITLE
use HTML Drag and Drop API [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Golden Layout is a Javascript layout manager which enables you to layout compone
 * Works in modern browsers (Firefox, Chrome)
 * Reponsive design
 
+The 'd-n-d-api' branch is an experimental fork making use
+of the [HTML Drag and Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API).
+This enables:
+
+* Drag from one window and drop to another.
+* Drag from one window and drop to desktop as new window (popout).
+* Cancel a drag (usually by typing Escape before releasing mouse).
+
+*This is experimental with an unstable API and known issues.*
+It is used in the`drag-drop` branch of [DomTerm](https://github.com/PerBothner/DomTerm/).
+
+The 'd-n-d-api' branch builds on the 'tab-renderer' branch,
+which is part of [GL pull request #759](https://github.com/golden-layout/golden-layout/pull/759).
+
 ## Installation
 The library can be installed into an application package with the npm command:\
 `npm i golden-layout`

--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -376,7 +376,6 @@ export class DragSource {
     constructor(
     _layoutManager: LayoutManager,
     _element: HTMLElement,
-    _extraAllowableChildTargets: HTMLElement[],
     _componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig),
     _componentState: JsonValue | undefined,
     _title: string | undefined);

--- a/src/less/goldenlayout-base.less
+++ b/src/less/goldenlayout-base.less
@@ -87,6 +87,16 @@
   }
 }
 
+.lm_headers {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+};
+
+.lm_component {
+  position: absolute;
+}
+
 // Pane Header (container of Tabs for each pane)
 .lm_header {
   overflow: visible;
@@ -112,18 +122,6 @@
       height: @height5;
       text-align: center;
     }
-  }
-
-  .lm_tabs {
-    display: flex;
-    overflow: hidden;
-  }
-
-  .lm_title {
-    display: inline-block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: pre;
   }
 
   // Single Tab container. A single Tab is set for each pane, a group of Tabs are contained in ".lm_header"
@@ -162,6 +160,19 @@
       right: 0;
       text-align: center;
     }
+  }
+}
+.lm_tabs {
+  display: flex;
+  overflow: hidden;
+}
+
+.lm_tab {
+  .lm_title {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre;
   }
 }
 

--- a/src/less/goldenlayout-base.less
+++ b/src/less/goldenlayout-base.less
@@ -116,6 +116,7 @@
 
   .lm_tabs {
     display: flex;
+    overflow: hidden;
   }
 
   .lm_title {
@@ -131,7 +132,7 @@
     float: left;
     height: @height2;
     margin-top: 1px;
-    padding: 0px 10px 5px;
+    padding: 0px 6px 5px;
     padding-right: 25px;
     position: relative;
     touch-action: none;
@@ -162,6 +163,25 @@
       text-align: center;
     }
   }
+}
+
+.lm_header.lm_tight_mode {
+    .lm_tabs {
+        .lm_tab {
+            padding-left: 2px;
+            padding-right: 2px;
+            .lm_close_tab {
+                display: none;
+            }
+        }
+        .lm_tab.lm_active {
+            display: inherit;
+            padding-right: 22px;
+            .lm_close_tab {
+                display: inherit;
+            }
+        }
+    }
 }
 
 // Change stack style to absolute positioning for docking transition ability

--- a/src/less/goldenlayout-base.less
+++ b/src/less/goldenlayout-base.less
@@ -3,7 +3,7 @@
 // can also be developed using SCSS.
 // All changes to base style should be done in goldenlayout-base.less.
 // Do NOT make changes directly in goldenlayout-base.scss.  goldenlayout-base.scss should only be updated by
-// running the npm script "update-scss"
+// running the npm script "update:scss"
 // Make sure that less code in goldenlayout.base.less can be correctly correctly converted to scss with less2sass (ie keep it basic)
 
 // Width variables (appears count calculates by raw css)
@@ -101,6 +101,7 @@
   // Pane controls (popout, maximize, minimize, close)
   .lm_controls {
     position: absolute;
+    top: 0px;
     right: 3px;
     display: flex;
 
@@ -114,8 +115,14 @@
   }
 
   .lm_tabs {
-    position: absolute;
     display: flex;
+  }
+
+  .lm_title {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre;
   }
 
   // Single Tab container. A single Tab is set for each pane, a group of Tabs are contained in ".lm_header"
@@ -143,12 +150,6 @@
         top: 0;
         right: -2px;
       }
-    }
-
-    .lm_title {
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     // Close Tab Icon
@@ -331,6 +332,10 @@
     right: 0;
     z-index: 5;
     overflow: hidden;
+    .lm_title {
+        display: block;
+        padding: 1px;
+    }
 
     .lm_tab {
       clear: both;

--- a/src/less/goldenlayout-base.less
+++ b/src/less/goldenlayout-base.less
@@ -9,7 +9,7 @@
 // Width variables (appears count calculates by raw css)
 @width0: 100%; // Appears 3 times
 @width1: 20px; // Appears 2 times
-@width2: 100px; // Appears 1 time
+@width2: 100px; // Appears 2 times
 @width3: 14px; // Appears 1 time
 @width4: 18px; // Appears 1 time
 @width5: 15px; // Appears 1 time
@@ -182,6 +182,10 @@
             }
         }
     }
+    .lm_drop_tab_placeholder {
+        padding-right: 0.7 * @width2;
+        margin-right: 0px; // counteract negative margin-left when taps overlap
+    }
 }
 
 // Change stack style to absolute positioning for docking transition ability
@@ -327,7 +331,7 @@
 
 .lm_drop_tab_placeholder {
   float: left;
-  width: @width2;
+  padding-right: @width2;
   height: @height3;
   visibility: hidden;
 }

--- a/src/scss/goldenlayout-base.scss
+++ b/src/scss/goldenlayout-base.scss
@@ -3,7 +3,7 @@
 // can also be developed using SCSS.
 // All changes to base style should be done in goldenlayout-base.scss.
 // Do NOT make changes directly in goldenlayout-base.scss.  goldenlayout-base.scss should only be updated by
-// running the npm script "update-scss"
+// running the npm script "update:scss"
 // Make sure that less code in goldenlayout.base.scss can be correctly correctly converted to scss with less2sass (ie keep it basic)
 
 // Width variables (appears count calculates by raw css)
@@ -101,6 +101,7 @@ $height6: 15px; // Appears 1 time
   // Pane controls (popout, maximize, minimize, close)
   .lm_controls {
     position: absolute;
+    top: 0px;
     right: 3px;
     display: flex;
 
@@ -114,8 +115,14 @@ $height6: 15px; // Appears 1 time
   }
 
   .lm_tabs {
-    position: absolute;
     display: flex;
+  }
+
+  .lm_title {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre;
   }
 
   // Single Tab container. A single Tab is set for each pane, a group of Tabs are contained in ".lm_header"
@@ -143,12 +150,6 @@ $height6: 15px; // Appears 1 time
         top: 0;
         right: -2px;
       }
-    }
-
-    .lm_title {
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     // Close Tab Icon
@@ -331,6 +332,10 @@ $height6: 15px; // Appears 1 time
     right: 0;
     z-index: 5;
     overflow: hidden;
+    .lm_title {
+        display: block;
+        padding: 1px;
+    }
 
     .lm_tab {
       clear: both;

--- a/src/scss/goldenlayout-base.scss
+++ b/src/scss/goldenlayout-base.scss
@@ -116,6 +116,7 @@ $height6: 15px; // Appears 1 time
 
   .lm_tabs {
     display: flex;
+    overflow: hidden;
   }
 
   .lm_title {
@@ -131,7 +132,7 @@ $height6: 15px; // Appears 1 time
     float: left;
     height: $height2;
     margin-top: 1px;
-    padding: 0px 10px 5px;
+    padding: 0px 6px 5px;
     padding-right: 25px;
     position: relative;
     touch-action: none;
@@ -162,6 +163,25 @@ $height6: 15px; // Appears 1 time
       text-align: center;
     }
   }
+}
+
+.lm_header.lm_tight_mode {
+    .lm_tabs {
+        .lm_tab {
+            padding-left: 2px;
+            padding-right: 2px;
+            .lm_close_tab {
+                display: none;
+            }
+        }
+        .lm_tab.lm_active {
+            display: inherit;
+            padding-right: 22px;
+            .lm_close_tab {
+                display: inherit;
+            }
+        }
+    }
 }
 
 // Change stack style to absolute positioning for docking transition ability

--- a/src/scss/goldenlayout-base.scss
+++ b/src/scss/goldenlayout-base.scss
@@ -87,6 +87,12 @@ $height6: 15px; // Appears 1 time
   }
 }
 
+.lm_headers {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+};
+
 // Pane Header (container of Tabs for each pane)
 .lm_header {
   overflow: visible;

--- a/src/ts/config/config.ts
+++ b/src/ts/config/config.ts
@@ -540,11 +540,25 @@ export namespace LayoutConfig {
          * Default: false
          */
         popInOnClose?: boolean;
+
+        useDragAndDrop?: boolean;
+
+        dragDataMimetype?: string;
+
+        /**
+         * Check whether location.search contains a gl-window parameter.
+         * This is used to handle window popin in simple cases.
+         * Default: true
+         */
+        checkGlWindowKey?: boolean;
     }
 
     export namespace Settings {
         export function resolve(settings: Settings | undefined): ResolvedLayoutConfig.Settings {
             const result: ResolvedLayoutConfig.Settings = {
+                useDragAndDrop: settings?.useDragAndDrop ?? false,
+                dragDataMimetype: settings?.dragDataMimetype ?? ResolvedLayoutConfig.Settings.defaults.dragDataMimetype,
+                checkGlWindowKey: settings?.checkGlWindowKey ?? true,
                 constrainDragToContainer: settings?.constrainDragToContainer ?? ResolvedLayoutConfig.Settings.defaults.constrainDragToContainer,
                 reorderEnabled: settings?.reorderEnabled ?? ResolvedLayoutConfig.Settings.defaults.reorderEnabled,
                 popoutWholeStack: settings?.popoutWholeStack ?? ResolvedLayoutConfig.Settings.defaults.popoutWholeStack,
@@ -572,6 +586,16 @@ export namespace LayoutConfig {
          * Default: 15
          */
         borderGrabWidth?: number,
+
+        /**
+         * Space to allocate between component wrapper and content element.
+         * This can be used for an 'outline'.
+         * This may affect drag from other window over iframe which may
+         * not trigger depending on the CSS pointer-events setting.
+         * (Uncertain: needs testing/experimentation.)
+         * Default: 2
+         */
+        contentInset: number;
 
         /**
          * The minimum height an item can be resized to (in pixel).
@@ -610,6 +634,7 @@ export namespace LayoutConfig {
             const result: ResolvedLayoutConfig.Dimensions = {
                 borderWidth: dimensions?.borderWidth ?? ResolvedLayoutConfig.Dimensions.defaults.borderWidth,
                 borderGrabWidth: dimensions?.borderGrabWidth ?? ResolvedLayoutConfig.Dimensions.defaults.borderGrabWidth,
+                contentInset: dimensions?.contentInset ?? ResolvedLayoutConfig.Dimensions.defaults.contentInset,
                 minItemHeight: dimensions?.minItemHeight ?? ResolvedLayoutConfig.Dimensions.defaults.minItemHeight,
                 minItemWidth: dimensions?.minItemWidth ?? ResolvedLayoutConfig.Dimensions.defaults.minItemWidth,
                 headerHeight: dimensions?.headerHeight ?? ResolvedLayoutConfig.Dimensions.defaults.headerHeight,

--- a/src/ts/config/resolved-config.ts
+++ b/src/ts/config/resolved-config.ts
@@ -392,6 +392,9 @@ export interface ResolvedLayoutConfig {
 /** @public */
 export namespace ResolvedLayoutConfig {
     export interface Settings {
+        readonly useDragAndDrop: boolean;
+        readonly dragDataMimetype: string;
+        readonly checkGlWindowKey: boolean;
         // see Config.Settings for comments
         readonly constrainDragToContainer: boolean;
         readonly reorderEnabled: boolean; // also in ResolvedItemConfig which takes precedence
@@ -407,6 +410,9 @@ export namespace ResolvedLayoutConfig {
 
     export namespace Settings {
         export const defaults: ResolvedLayoutConfig.Settings = {
+            useDragAndDrop: true,
+            dragDataMimetype: 'text/gl-drag-data',
+            checkGlWindowKey: true,
             constrainDragToContainer: true,
             reorderEnabled: true,
             popoutWholeStack: false,
@@ -421,6 +427,9 @@ export namespace ResolvedLayoutConfig {
 
         export function createCopy(original: Settings): Settings {
             return {
+                useDragAndDrop: original.useDragAndDrop,
+                dragDataMimetype: original.dragDataMimetype,
+                checkGlWindowKey: original.checkGlWindowKey,
                 constrainDragToContainer: original.constrainDragToContainer,
                 reorderEnabled: original.reorderEnabled,
                 popoutWholeStack: original.popoutWholeStack,
@@ -439,6 +448,7 @@ export namespace ResolvedLayoutConfig {
         // see LayoutConfig.Dimensions for comments
         readonly borderWidth: number;
         readonly borderGrabWidth: number,
+        readonly contentInset: number,
         readonly minItemHeight: number;
         readonly minItemWidth: number;
         readonly headerHeight: number;
@@ -451,6 +461,7 @@ export namespace ResolvedLayoutConfig {
             return {
                 borderWidth: original.borderWidth,
                 borderGrabWidth: original.borderGrabWidth,
+                contentInset: original.contentInset,
                 minItemHeight: original.minItemHeight,
                 minItemWidth: original.minItemWidth,
                 headerHeight: original.headerHeight,
@@ -462,6 +473,7 @@ export namespace ResolvedLayoutConfig {
         export const defaults: ResolvedLayoutConfig.Dimensions = {
             borderWidth: 5,
             borderGrabWidth: 5,
+            contentInset: 2,
             minItemHeight: 10,
             minItemWidth: 10,
             headerHeight: 20,

--- a/src/ts/container/component-container.ts
+++ b/src/ts/container/component-container.ts
@@ -279,6 +279,10 @@ export class ComponentContainer extends EventEmitter {
         this._parent.setTitle(title);
     }
 
+    setTitleRenderer(renderer: Tab.TitleRenderer | undefined): void {
+        this._parent.setTitleRenderer(renderer);
+    }
+
     /** @internal */
     setTab(tab: Tab): void {
         this._tab = tab;

--- a/src/ts/controls/drag-source.ts
+++ b/src/ts/controls/drag-source.ts
@@ -28,8 +28,6 @@ export class DragSource {
         /** @internal */
         private readonly _element: HTMLElement,
         /** @internal */
-        private readonly _extraAllowableChildTargets: HTMLElement[],
-        /** @internal */
         private _componentTypeOrFtn: JsonValue | (() => DragSource.ComponentItemConfig),
         /** @internal */
         private _componentState: JsonValue | undefined,
@@ -61,7 +59,7 @@ export class DragSource {
     private createDragListener() {
         this.removeDragListener();
 
-        this._dragListener = new DragListener(this._element, this._extraAllowableChildTargets);
+        this._dragListener = new DragListener(this._element);
         this._dragListener.on('dragStart', (x, y) => this.onDragStart(x, y));
         this._dragListener.on('dragStop', () => this.onDragStop());
     }

--- a/src/ts/controls/drop-target-indicator.ts
+++ b/src/ts/controls/drop-target-indicator.ts
@@ -6,7 +6,7 @@ import { numberToPixels, setElementDisplayVisibility } from '../utils/utils';
 export class DropTargetIndicator {
     private _element: HTMLElement;
 
-    constructor() {
+    constructor(parent: HTMLElement = document.body) {
         // Maybe use container instead of Document Body?
         this._element = document.createElement('div');
         this._element.classList.add(DomConstants.ClassName.DropTargetIndicator);
@@ -14,7 +14,7 @@ export class DropTargetIndicator {
         innerElement.classList.add(DomConstants.ClassName.Inner);
         this._element.appendChild(innerElement);
 
-        document.body.appendChild(this._element);
+        parent.appendChild(this._element);
     }
 
     destroy(): void {

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -72,6 +72,8 @@ export class Header extends EventEmitter {
     private readonly _tabDropdownButton: HeaderButton;
     /** @internal */
     private readonly _maximiseButton: HeaderButton | undefined;
+    /** @internal */
+    private _updateRequested: number = 0;
     // /** @internal */
     // private _activeComponentItem: ComponentItem | null = null; // only used to identify active tab
 
@@ -315,18 +317,24 @@ export class Header extends EventEmitter {
      * @internal
      */
     updateTabSizes(): void {
-        if (this._tabsContainer.tabCount > 0) {
-            const headerHeight = this._show ? this._layoutManager.layoutConfig.dimensions.headerHeight : 0;
+        if (this._updateRequested)
+            return;
+        this._updateRequested = window.requestAnimationFrame((now) => {
+            this._updateRequested = 0;
 
-            if (this._leftRightSided) {
-                this._element.style.height = '';
-                this._element.style.width = numberToPixels(headerHeight);
-            } else {
-                this._element.style.width = '';
-                this._element.style.height = numberToPixels(headerHeight);
+            if (this._tabsContainer.tabCount > 0) {
+                const headerHeight = this._show ? this._layoutManager.layoutConfig.dimensions.headerHeight : 0;
+
+                if (this._leftRightSided) {
+                    this._element.style.height = '';
+                    this._element.style.width = numberToPixels(headerHeight);
+                } else {
+                    this._element.style.width = '';
+                    this._element.style.height = numberToPixels(headerHeight);
+                }
+                this._tabsContainer.updateTabSizes(this, this._getActiveComponentItemEvent());
             }
-            this._tabsContainer.updateTabSizes(this, this._getActiveComponentItemEvent());
-        }
+        });
     }
 
     availableTabsSize(): number {

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -191,20 +191,27 @@ export class Header extends EventEmitter {
      * @internal
      */
     destroy(): void {
-        this.emit('destroy');
+        this._element.style.opacity = '0';
+        this.layoutManager.deferIfDragging((cancel) => {
+            if (cancel) {
+                this._element.style.opacity = '';
+            } else {
+                this.emit('destroy');
 
-        this._popoutEvent = undefined;
-        this._maximiseToggleEvent = undefined;
-        this._clickEvent = undefined;
-        this._touchStartEvent = undefined;
-        this._componentRemoveEvent = undefined;
-        this._componentFocusEvent = undefined;
-        this._componentDragStartEvent = undefined;
+                this._popoutEvent = undefined;
+                this._maximiseToggleEvent = undefined;
+                this._clickEvent = undefined;
+                this._touchStartEvent = undefined;
+                this._componentRemoveEvent = undefined;
+                this._componentFocusEvent = undefined;
+                this._componentDragStartEvent = undefined;
 
-        this._tabsContainer.destroy();
+                this._tabsContainer.destroy();
 
-        globalThis.document.removeEventListener('mouseup', this._documentMouseUpListener);
-        this.layoutManager.removeElementEventually(this._element);
+                globalThis.document.removeEventListener('mouseup', this._documentMouseUpListener);
+                this._element.remove();
+            }
+        });
     }
 
     /**

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -73,7 +73,7 @@ export class Header extends EventEmitter {
     /** @internal */
     private readonly _maximiseButton: HeaderButton | undefined;
     /** @internal */
-    private _updateRequested: number = 0;
+    private _updateRequested = 0;
     // /** @internal */
     // private _activeComponentItem: ComponentItem | null = null; // only used to identify active tab
 
@@ -319,7 +319,7 @@ export class Header extends EventEmitter {
     updateTabSizes(): void {
         if (this._updateRequested)
             return;
-        this._updateRequested = window.requestAnimationFrame((now) => {
+        this._updateRequested = window.requestAnimationFrame(() => {
             this._updateRequested = 0;
 
             if (this._tabsContainer.tabCount > 0) {

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -325,14 +325,15 @@ export class Header extends EventEmitter {
                 this._element.style.width = '';
                 this._element.style.height = numberToPixels(headerHeight);
             }
-            let availableWidth: number;
-            if (this._leftRightSided) {
-                availableWidth = this._element.offsetHeight - this._controlsContainerElement.offsetHeight - this._tabControlOffset;
-            } else {
-                availableWidth = this._element.offsetWidth - this._controlsContainerElement.offsetWidth - this._tabControlOffset;
-            }
+            this._tabsContainer.updateTabSizes(this, this._getActiveComponentItemEvent());
+        }
+    }
 
-            this._tabsContainer.updateTabSizes(availableWidth, this._getActiveComponentItemEvent());
+    availableTabsSize(): number {
+        if (this._leftRightSided) {
+            return this._element.offsetHeight - this._controlsContainerElement.offsetHeight - this._tabControlOffset;
+        } else {
+            return this._element.offsetWidth - this._controlsContainerElement.offsetWidth - this._tabControlOffset;
         }
     }
 

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -149,8 +149,8 @@ export class Header extends EventEmitter {
         this._element.appendChild(this._controlsContainerElement);
         this._element.appendChild(this._tabsContainer.dropdownElement);
 
-        this._element.addEventListener('click', this._clickListener, { passive: true });
-        this._element.addEventListener('touchstart', this._touchStartListener, { passive: true });
+        //        this._element.addEventListener('click', this._clickListener, { passive: true });
+        //this._element.addEventListener('touchstart', this._touchStartListener, { passive: true });
 
         this._documentMouseUpListener = () => this._tabsContainer.hideAdditionalTabsDropdown()
         globalThis.document.addEventListener('mouseup', this._documentMouseUpListener, { passive: true });
@@ -164,7 +164,7 @@ export class Header extends EventEmitter {
         }
 
         if (this._popoutEnabled) {
-            this._popoutButton = new HeaderButton(this, this._popoutLabel, DomConstants.ClassName.Popout, () => this.handleButtonPopoutEvent());
+            this._popoutButton = new HeaderButton(this, this._popoutLabel, DomConstants.ClassName.Popout, (ev) => this.handleButtonPopoutEvent(ev));
         }
 
         /**
@@ -204,7 +204,7 @@ export class Header extends EventEmitter {
         this._tabsContainer.destroy();
 
         globalThis.document.removeEventListener('mouseup', this._documentMouseUpListener);
-        this._element.remove();
+        this.layoutManager.removeElementEventually(this._element);
     }
 
     /**
@@ -324,7 +324,8 @@ export class Header extends EventEmitter {
 
             if (this._tabsContainer.tabCount > 0) {
                 const headerHeight = this._show ? this._layoutManager.layoutConfig.dimensions.headerHeight : 0;
-
+                /* We need explicit this._element.style.width
+                * if the header is in an lm_header container.
                 if (this._leftRightSided) {
                     this._element.style.height = '';
                     this._element.style.width = numberToPixels(headerHeight);
@@ -332,6 +333,7 @@ export class Header extends EventEmitter {
                     this._element.style.width = '';
                     this._element.style.height = numberToPixels(headerHeight);
                 }
+                */
                 this._tabsContainer.updateTabSizes(this, this._getActiveComponentItemEvent());
             }
         });
@@ -386,7 +388,9 @@ export class Header extends EventEmitter {
     }
 
     /** @internal */
-    private handleButtonPopoutEvent() {
+    private handleButtonPopoutEvent(ev: Event) {
+        if (this._layoutManager.popoutClickHandler(this.parent, ev))
+            return;
         if (this._layoutManager.layoutConfig.settings.popoutWholeStack) {
             if (this._popoutEvent === undefined) {
                 throw new UnexpectedUndefinedError('HHBPOE17834');

--- a/src/ts/controls/splitter.ts
+++ b/src/ts/controls/splitter.ts
@@ -19,6 +19,7 @@ export class Splitter {
         this._element.classList.add(DomConstants.ClassName.Splitter);
         const dragHandleElement = document.createElement('div');
         dragHandleElement.classList.add(DomConstants.ClassName.DragHandle);
+        this._element.setAttribute('draggable', 'yes');
 
         const handleExcessSize = this._grabSize - this._size;
         const handleExcessPos = handleExcessSize / 2;
@@ -37,7 +38,7 @@ export class Splitter {
 
         this._element.appendChild(dragHandleElement);
 
-        this._dragListener = new DragListener(this._element, [dragHandleElement]);
+        this._dragListener = new DragListener(this._element);
     }
 
     destroy(): void {

--- a/src/ts/controls/splitter.ts
+++ b/src/ts/controls/splitter.ts
@@ -19,7 +19,7 @@ export class Splitter {
         this._element.classList.add(DomConstants.ClassName.Splitter);
         const dragHandleElement = document.createElement('div');
         dragHandleElement.classList.add(DomConstants.ClassName.DragHandle);
-        this._element.setAttribute('draggable', 'yes');
+        this._element.setAttribute('draggable', 'true');
 
         const handleExcessSize = this._grabSize - this._size;
         const handleExcessPos = handleExcessSize / 2;

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -118,9 +118,10 @@ export class Tab {
      * html tags) of the same string.
      */
     setTitle(title: string): void {
-        this._titleElement.innerText = title;
         this._element.title = title;
-        (this.componentItem.parent as Stack).updateTabSizes();
+        const parent = this.componentItem.parent;
+        if (parent instanceof Stack)
+            parent.header.updateTabSizes();
     }
 
     /**

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -5,6 +5,7 @@ import { Stack } from '../items/stack';
 import { LayoutManager } from '../layout-manager';
 import { DomConstants } from '../utils/dom-constants';
 import { DragListener } from '../utils/drag-listener';
+import { enableIFramePointerEvents } from '../utils/utils';
 
 /**
  * Represents an individual tab within a Stack's header
@@ -198,7 +199,7 @@ export class Tab {
         // See drag-listener#startDrag
         document.body.classList.add(DomConstants.ClassName.Dragging);
         this._element.classList.add(DomConstants.ClassName.Dragging);
-        document.querySelector('iframe')?.style.setProperty('pointer-events', 'none');
+        enableIFramePointerEvents(false);
         // FIXME: set non-maximized
         this._layoutManager.startComponentDrag(e, 0, 0, this.componentItem);
     }

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -76,6 +76,8 @@ export class Tab {
         this._titleElement.classList.add(DomConstants.ClassName.Title);
         this._closeElement = document.createElement('div'); 
         this._closeElement.classList.add(DomConstants.ClassName.CloseTab);
+        this._element.setAttribute('draggable', 'yes');
+        this._closeElement.setAttribute('draggable', 'no');
         this._element.appendChild(this._titleElement);
         this._element.appendChild(this._closeElement);
 
@@ -265,7 +267,7 @@ export class Tab {
 
     /** @internal */
     private enableReorder() {
-        this._dragListener = new DragListener(this._element, [this._titleElement]);
+        this._dragListener = new DragListener(this._element);
         this._dragListener.on('dragStart', this._dragStartListener);
         this._componentItem.on('destroy', this._contentItemDestroyListener);
     }

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -76,8 +76,8 @@ export class Tab {
         this._titleElement.classList.add(DomConstants.ClassName.Title);
         this._closeElement = document.createElement('div'); 
         this._closeElement.classList.add(DomConstants.ClassName.CloseTab);
-        this._element.setAttribute('draggable', 'yes');
-        this._closeElement.setAttribute('draggable', 'no');
+        this._element.setAttribute('draggable', 'true');
+        this._closeElement.setAttribute('draggable', 'false');
         this._element.appendChild(this._titleElement);
         this._element.appendChild(this._closeElement);
 

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -201,7 +201,7 @@ export class Tab {
         this._element.classList.add(DomConstants.ClassName.Dragging);
         enableIFramePointerEvents(false);
         // FIXME: set non-maximized
-        this._layoutManager.startComponentDrag(e, 0, 0, this.componentItem);
+        this._layoutManager.startComponentDrag(e, this.componentItem);
     }
 
     /** @internal */

--- a/src/ts/controls/tab.ts
+++ b/src/ts/controls/tab.ts
@@ -37,7 +37,7 @@ export class Tab {
     private readonly _contentItemDestroyListener = () => this.onContentItemDestroy();
     /** @internal */
     private readonly _tabTitleChangedListener = (title: string) => this.setTitle(title);
-    readonly tabClickListener = (ev: MouseEvent) => this.onTabClickDown(ev);
+    readonly tabClickListener = (ev: MouseEvent): void => this.onTabClickDown(ev);
     get isActive(): boolean { return this._isActive; }
     // get header(): Header { return this._header; }
     get componentItem(): ComponentItem { return this._componentItem; }
@@ -299,7 +299,7 @@ export namespace Tab {
         DropdownActive = 1,
         InDropdownMenu = 2,
         IsActiveTab = 4,
-    };
+    }
     export type TitleRenderer = (component: ComponentContainer, target: HTMLElement, availableWidth: number, flags: RenderFlags)=>void;
     /** @internal */
     export type CloseEvent = (componentItem: ComponentItem) => void;

--- a/src/ts/controls/tabs-container.ts
+++ b/src/ts/controls/tabs-container.ts
@@ -182,12 +182,14 @@ export class TabsContainer {
                 tabElement.style.display = '';
 
                 const component = tab.componentItem;
-                const renderer: Tab.TitleRenderer =
-                    component.titleRenderer ? component.titleRenderer :
-                      (container, el, width, dropdownActive) => {
-                          while (el.lastChild) { el.removeChild(el.lastChild); }
-                          el.appendChild(document.createTextNode(component.title));
-                      };
+                const renderer: Tab.TitleRenderer = (container, el, width, flags)  => {
+                    if (component.titleRenderer) {
+                        component.titleRenderer(container, el, width, flags);
+                    } else {
+                        while (el.lastChild) { el.removeChild(el.lastChild); }
+                        el.appendChild(document.createTextNode(component.title));
+                    }
+                };
                 //Put the tab in the tabContainer so its true width can be checked
                 if (tabElement.parentElement !== this._element) {
                     this._element.appendChild(tabElement);
@@ -203,10 +205,10 @@ export class TabsContainer {
 
                 //Include the active tab's width if it isn't already
                 //This is to ensure there is room to show the active tab
-                let visibleTabWidth = cumulativeTabWidth;
+                const visibleTabWidth = cumulativeTabWidth;
 
                 if (dropdownActive) {
-                    let el = document.createElement('span');
+                    const el = document.createElement('span');
                     el.classList.add(DomConstants.ClassName.Title);
                     const w = availableWidth * 0.9;
                     renderer(component.container, el, w,

--- a/src/ts/controls/tabs-container.ts
+++ b/src/ts/controls/tabs-container.ts
@@ -88,9 +88,13 @@ export class TabsContainer {
             if (this._tabs[i].componentItem === componentItem) {
                 const tab = this._tabs[i];
                 tab.destroy();
-                this._tabs.splice(i, 1);
-                if (i <= this._lastVisibleTabIndex)
-                    --this._lastVisibleTabIndex;
+                this._layoutManager.deferIfDragging((cancel) => {
+                    if (! cancel) {
+                        this._tabs.splice(i, 1);
+                        if (i <= this._lastVisibleTabIndex)
+                            --this._lastVisibleTabIndex;
+                    }
+                });
                 return;
             }
         }

--- a/src/ts/controls/tabs-container.ts
+++ b/src/ts/controls/tabs-container.ts
@@ -89,6 +89,8 @@ export class TabsContainer {
                 const tab = this._tabs[i];
                 tab.destroy();
                 this._tabs.splice(i, 1);
+                if (i <= this._lastVisibleTabIndex)
+                    --this._lastVisibleTabIndex;
                 return;
             }
         }

--- a/src/ts/items/component-item.ts
+++ b/src/ts/items/component-item.ts
@@ -75,8 +75,19 @@ export class ComponentItem extends ContentItem {
 
     /** @internal */
     override destroy(): void {
-        this._container.destroy()
-        super.destroy();
+        const element = this.element;
+        element.style.display = 'none';
+        const wasDragging = this.layoutManager._currentlyDragging;
+        this.layoutManager.deferIfDragging((cancel) => {
+            if (! cancel) {
+                if (wasDragging)
+                    element.style.display = '';
+                else {
+                    this._container.destroy();
+                    super.destroy();
+                }
+            }
+        });
     }
 
     applyUpdatableConfig(config: ResolvedComponentItemConfig): void {

--- a/src/ts/items/component-item.ts
+++ b/src/ts/items/component-item.ts
@@ -24,6 +24,8 @@ export class ComponentItem extends ContentItem {
     /** @internal */
     private _tab: Tab;
     /** @internal */
+    private _titleRenderer: Tab.TitleRenderer | undefined;
+    /** @internal */
     private _focused = false;
 
     /** @internal @deprecated use {@link (ComponentItem:class).componentType} */
@@ -38,6 +40,7 @@ export class ComponentItem extends ContentItem {
 
     get headerConfig(): ResolvedHeaderedItemConfig.Header | undefined { return this._headerConfig; }
     get title(): string { return this._title; }
+    get titleRenderer(): Tab.TitleRenderer | undefined { return this._titleRenderer; }
     get tab(): Tab { return this._tab; }
     get focused(): boolean { return this._focused; }
 
@@ -166,6 +169,12 @@ export class ComponentItem extends ContentItem {
     setTitle(title: string): void {
         this._title = title;
         this.emit('titleChanged', title);
+        this.emit('stateChanged');
+    }
+
+    setTitleRenderer(renderer: Tab.TitleRenderer | undefined): void {
+        this._titleRenderer = renderer;
+        this.emit('titleChanged', this._title);
         this.emit('stateChanged');
     }
 

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -204,7 +204,8 @@ export abstract class ContentItem extends EventEmitter {
         if (parentNode === null) {
             throw new UnexpectedNullError('CIRCP23232');
         } else {
-            parentNode.replaceChild(newChild._element, oldChild._element);
+            //if (!this.layoutManager._currentlyDragging)
+                parentNode.replaceChild(newChild._element, oldChild._element);
 
             /*
             * Optionally destroy the old content item
@@ -213,6 +214,7 @@ export abstract class ContentItem extends EventEmitter {
                 oldChild._parent = null;
                 oldChild.destroy(); // will now also destroy all children of oldChild
             }
+//            }
 
             /*
             * Wire the new contentItem into the tree

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -36,8 +36,8 @@ export abstract class ContentItem extends EventEmitter {
     /** @internal */
     private _isInitialised;
 
-    ignoring: boolean = false;
-    ignoringChild: boolean = false;
+    ignoring = false;
+    ignoringChild = false;
     /** @internal */
     width: number; // pixels
     /** @internal */

--- a/src/ts/items/ground-item.ts
+++ b/src/ts/items/ground-item.ts
@@ -29,6 +29,13 @@ export class GroundItem extends ComponentParentableItem {
         this._containerElement = containerElement;
 
         // insert before any pre-existing content elements
+        const before = this._containerElement.firstChild;
+        /* This logic needs to updated to not use ClassName.Content.
+         * However, it also fails because  _dropTargetIndicator and _transitionIndicator
+         * are insert after pre-existing content elements.
+         * It used to work because GoldenLayout@bindComponent would do:
+         * this.container.appendChild(componentRootElement)
+         * which seems counter to the goal of not moving content elements.
         let before = null;
         while (true) {
             const prev: ChildNode | null =
@@ -40,6 +47,7 @@ export class GroundItem extends ComponentParentableItem {
                 break;
             }
         }
+        */
         this._containerElement.insertBefore(this.element, before);
     }
 

--- a/src/ts/items/ground-item.ts
+++ b/src/ts/items/ground-item.ts
@@ -357,8 +357,14 @@ export class GroundItem extends ComponentParentableItem {
     private deepGetAllContentItems(content: readonly ContentItem[], result: ContentItem[]): void {
         for (let i = 0; i < content.length; i++) {
             const contentItem = content[i];
-            result.push(contentItem);
-            this.deepGetAllContentItems(contentItem.contentItems, result);
+            const children = contentItem.contentItems;
+            if (! contentItem.ignoring) {
+                if (! contentItem.ignoringChild
+                    || (contentItem.type !== ItemType.row && contentItem.type !== ItemType.column)
+                    || children.length > 2)
+                    result.push(contentItem);
+                this.deepGetAllContentItems(children, result);
+            }
         }
     }
 

--- a/src/ts/items/row-or-column.ts
+++ b/src/ts/items/row-or-column.ts
@@ -348,7 +348,7 @@ export class RowOrColumn extends ContentItem {
         const itemSizes = [];
 
         for (const item of this.contentItems) {
-            let itemSize: number =
+            const itemSize: number =
                 item.ignoring ? 0
                 : this._isColumn ? Math.floor(totalHeight * (item.height / 100))
                 : Math.floor(totalWidth * (item.width / 100));

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -45,7 +45,7 @@ export class Stack extends ComponentParentableItem {
     private _initialActiveItemIndex: number;
 
     /** @internal */
-    private _resizeListener = () => this.handleResize();
+    private _resizeListener = () => this.updateTabSizes();
     /** @internal */
     private _maximisedListener = () => this.handleMaximised();
     /** @internal */
@@ -186,7 +186,7 @@ export class Stack extends ComponentParentableItem {
 
                 this.setActiveComponentItem(contentItems[this._initialActiveItemIndex] as ComponentItem, false);
 
-                this._header.updateTabSizes();
+                this.updateTabSizes();
             }
         }
 
@@ -839,9 +839,9 @@ export class Stack extends ComponentParentableItem {
         }
     }
 
-    /** @internal */
-    private handleResize() {
-        this._header.updateTabSizes()
+    updateTabSizes(): void {
+        if (this._header)
+            this._header.updateTabSizes();
     }
 
     /** @internal */

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -137,7 +137,7 @@ export class Stack extends ComponentParentableItem {
             this.on('minimised', this._minimisedListener);
         }
 
-        this.element.appendChild(this._header.element);
+        this.layoutManager.headersContainerElement.appendChild(this._header.element);
         this.element.appendChild(this._childElementContainer);
 
         this.setupHeaderPosition();
@@ -150,6 +150,11 @@ export class Stack extends ComponentParentableItem {
         try {
             this.updateNodeSize();
             this.updateContentItemsSize();
+            const rect = this.element.getBoundingClientRect();
+            const layoutBounds = this.layoutManager.container.getBoundingClientRect();
+            this._header.element.style.width = numberToPixels(rect.width);
+            this._header.element.style.top = numberToPixels(rect.top - layoutBounds.top);
+            this._header.element.style.left = numberToPixels(rect.left - layoutBounds.left);
         } finally {
             this.layoutManager.endVirtualSizedContainerAdding();
         }
@@ -162,7 +167,7 @@ export class Stack extends ComponentParentableItem {
         this.updateNodeSize();
 
         for (let i = 0; i < this.contentItems.length; i++) {
-            this._childElementContainer.appendChild(this.contentItems[i].element);
+            // this._childElementContainer.appendChild(this.contentItems[i].element);
         }
 
         super.init();
@@ -293,7 +298,7 @@ export class Stack extends ComponentParentableItem {
             throw new AssertError('SACC88532'); // Stacks can only have Component children
         } else {
             index = super.addChild(contentItem, index);
-            this._childElementContainer.appendChild(contentItem.element);
+            //this._childElementContainer.appendChild(contentItem.element);
             this._header.createTab(contentItem, index);
             this.setActiveComponentItem(contentItem, focus);
             this._header.updateTabSizes();
@@ -694,10 +699,22 @@ export class Stack extends ComponentParentableItem {
         if (this.element.style.display !== 'none') {
             const content: WidthAndHeight = getElementWidthAndHeight(this.element);
 
+            let headerHeight;
             if (this._header.show) {
                 const dimension = this._header.leftRightSided ? WidthOrHeightPropertyName.width : WidthOrHeightPropertyName.height;
-                content[dimension] -= this.layoutManager.layoutConfig.dimensions.headerHeight;
+                headerHeight = this.layoutManager.layoutConfig.dimensions.headerHeight;
+                content[dimension] -= headerHeight;
+                if (content[dimension] <= 0) {
+                    console.log("non-positive content["+dimension+"] size "+content[dimension]);
+                }
+            } else {
+                headerHeight = 0;
             }
+            this._header.element.style.position = 'absolute';
+            this._header.element.style.width = numberToPixels(content.width);
+            this._childElementContainer.style.position = 'relative';
+            this._childElementContainer.style.top = numberToPixels(headerHeight);
+            this._childElementContainer.style.bottom = '0px';
             this._childElementContainer.style.width = numberToPixels(content.width);
             this._childElementContainer.style.height = numberToPixels(content.height);
             for (let i = 0; i < this.contentItems.length; i++) {
@@ -888,7 +905,7 @@ export class Stack extends ComponentParentableItem {
         if (this.isMaximised === true) {
             this.toggleMaximise();
         }
-        this.layoutManager.startComponentDrag(x, y, dragListener, componentItem, this);
+        this.layoutManager.startComponentDragOld(x, y, dragListener, componentItem, this);
     }
 
     /** @internal */

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -721,6 +721,7 @@ export class Stack extends ComponentParentableItem {
 
         let area: AreaLinkedRect;
 
+        const tabDropPlaceholder = this.layoutManager.tabDropPlaceholder;
         // Empty stack
         if (tabsLength === 0) {
             const headerOffset = getJQueryOffset(this._header.element);
@@ -771,14 +772,13 @@ export class Stack extends ComponentParentableItem {
 
             if (x < halfX) {
                 this._dropIndex = tabIndex;
-                tabElement.insertAdjacentElement('beforebegin', this.layoutManager.tabDropPlaceholder);
+                tabElement.insertAdjacentElement('beforebegin', tabDropPlaceholder);
             } else {
                 this._dropIndex = Math.min(tabIndex + 1, tabsLength);
-                tabElement.insertAdjacentElement('afterend', this.layoutManager.tabDropPlaceholder);
+                tabElement.insertAdjacentElement('afterend', tabDropPlaceholder);
             }
-
-            const tabDropPlaceholderOffset = getJQueryOffset(this.layoutManager.tabDropPlaceholder);
-            const tabDropPlaceholderWidth = getElementWidth(this.layoutManager.tabDropPlaceholder)
+            const tabDropPlaceholderOffset = getJQueryOffset(tabDropPlaceholder);
+            const tabDropPlaceholderWidth = getElementWidth(tabDropPlaceholder);
             if (this._header.leftRightSided) {
                 const placeHolderTop = tabDropPlaceholderOffset.top;
                 area = {

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -70,7 +70,7 @@ export abstract class LayoutManager extends EventEmitter {
     private _resizeTimeoutId: ReturnType<typeof setTimeout> | undefined;
     /** @internal */
     private _itemAreas: ContentItem.Area[] | null = null;
-    _currentlyDragging: boolean = false;
+    _currentlyDragging = false;
     _draggedComponentItem: ComponentItem | undefined;
     /** @internal */
     private _dragEnterCount = 0;

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -1734,13 +1734,6 @@ export namespace LayoutManager {
     }
 
     /** @public */
-    export enum RenderFlags {
-        DropdownActive = 1,
-        InDropdownManu = 2,
-        IsActiveTab = 4,
-    };
-
-    /** @public */
     export namespace LocationSelector {
         export const enum TypeId {
             /** Stack with focused Item. Index specifies offset from index of focused item (eg 1 is the position after focused item) */

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -1734,6 +1734,13 @@ export namespace LayoutManager {
     }
 
     /** @public */
+    export enum RenderFlags {
+        DropdownActive = 1,
+        InDropdownManu = 2,
+        IsActiveTab = 4,
+    };
+
+    /** @public */
     export namespace LocationSelector {
         export const enum TypeId {
             /** Stack with focused Item. Index specifies offset from index of focused item (eg 1 is the position after focused item) */

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -899,7 +899,7 @@ export abstract class LayoutManager extends EventEmitter {
         componentState?: JsonValue,
         title?: string,
     ): DragSource {
-        const dragSource = new DragSource(this, element, [], componentTypeOrItemConfigCallback, componentState, title);
+        const dragSource = new DragSource(this, element, componentTypeOrItemConfigCallback, componentState, title);
         this._dragSources.push(dragSource);
 
         return dragSource;

--- a/src/ts/utils/dom-constants.ts
+++ b/src/ts/utils/dom-constants.ts
@@ -14,6 +14,7 @@ export namespace DomConstants {
         Dragging = 'lm_dragging',
         DragProxy = 'lm_dragProxy',
         Header = 'lm_header',
+        Headers = 'lm_headers',
         Tabs = 'lm_tabs',
         Tab = 'lm_tab',
         CloseTab = 'lm_close_tab',

--- a/src/ts/utils/drag-listener.ts
+++ b/src/ts/utils/drag-listener.ts
@@ -68,7 +68,7 @@ export class DragListener extends EventEmitter {
             if (! (target instanceof HTMLElement))
                 return;
             const draggable = target.getAttribute('draggable');
-            if (draggable === 'yes')
+            if (draggable === 'true')
                 break;
             if (draggable !== null)
                 return;

--- a/src/ts/utils/drag-listener.ts
+++ b/src/ts/utils/drag-listener.ts
@@ -1,5 +1,6 @@
 import { DomConstants } from './dom-constants';
 import { EventEmitter } from './event-emitter';
+import { enableIFramePointerEvents } from './utils';
 
 /** @internal */
 export class DragListener extends EventEmitter {
@@ -138,7 +139,7 @@ export class DragListener extends EventEmitter {
         if (this._dragging === true) {
             this._eBody.classList.remove(DomConstants.ClassName.Dragging);
             this._eElement.classList.remove(DomConstants.ClassName.Dragging);
-            this._oDocument.querySelector('iframe')?.style.setProperty('pointer-events', '');
+            enableIFramePointerEvents(true);
             this._dragging = false;
             this.emit('dragStop', dragEvent);
         }
@@ -160,7 +161,7 @@ export class DragListener extends EventEmitter {
         this._dragging = true;
         this._eBody.classList.add(DomConstants.ClassName.Dragging);
         this._eElement.classList.add(DomConstants.ClassName.Dragging);
-        this._oDocument.querySelector('iframe')?.style.setProperty('pointer-events', 'none');
+        enableIFramePointerEvents(false);
         this.emit('dragStart', this._nOriginalX, this._nOriginalY);
     }
 

--- a/src/ts/utils/drag-listener.ts
+++ b/src/ts/utils/drag-listener.ts
@@ -63,20 +63,18 @@ export class DragListener extends EventEmitter {
         this.processDragStop(undefined);
     }
 
-    private allowableTarget(target: EventTarget | null): boolean {
-        for (; target instanceof HTMLElement; target = target.parentNode) {
+    private onPointerDown(oEvent: PointerEvent) {
+        for (let target = oEvent.target; ; target = target.parentNode) {
+            if (! (target instanceof HTMLElement))
+                return;
             const draggable = target.getAttribute('draggable');
             if (draggable === 'yes')
-                return true;
-            if (draggable !== null)
                 break;
+            if (draggable !== null)
+                return;
         }
-        return false;
-    }
 
-    private onPointerDown(oEvent: PointerEvent) {
-        if (this.allowableTarget(oEvent.target))
-            this.processPointerDown(this.getPointerCoordinates(oEvent));
+        this.processPointerDown(this.getPointerCoordinates(oEvent));
     }
 
     private processPointerDown(coordinates: DragListener.PointerCoordinates) {

--- a/src/ts/utils/event-emitter.ts
+++ b/src/ts/utils/event-emitter.ts
@@ -181,7 +181,9 @@ export namespace EventEmitter {
         "closed": NoParams;
         "destroy": NoParams;
         "drag": DragParams;
-        "dragStart": DragStartParams;
+        "dragstart": DragEventParams; // Native (new-style) drag
+        "dragend": DragEventParams; // Native (new-style) drag
+        "dragStart": DragStartParams; // Non-native (old-style) drag
         "dragStop": DragStopParams;
         "dragExported": ComponentItemParam;
         "hide": NoParams;
@@ -223,6 +225,7 @@ export namespace EventEmitter {
     export type DragStartParams = [originalX: number, originalY: number];
     export type DragStopParams = [event: PointerEvent | undefined];
     export type DragParams = [offsetX: number, offsetY: number, event: PointerEvent];
+    export type DragEventParams = [event: DragEvent];
     export type BeforeComponentReleaseParams = [component: unknown];
     export type ClickBubblingEventParam = [ClickBubblingEvent];
     export type TouchStartBubblingEventParam = [TouchStartBubblingEvent];

--- a/src/ts/utils/event-emitter.ts
+++ b/src/ts/utils/event-emitter.ts
@@ -183,6 +183,7 @@ export namespace EventEmitter {
         "drag": DragParams;
         "dragStart": DragStartParams;
         "dragStop": DragStopParams;
+        "dragExported": ComponentItemParam;
         "hide": NoParams;
         "initialised": NoParams;
         "itemDropped": ComponentItemParam;

--- a/src/ts/utils/event-emitter.ts
+++ b/src/ts/utils/event-emitter.ts
@@ -181,8 +181,10 @@ export namespace EventEmitter {
         "closed": NoParams;
         "destroy": NoParams;
         "drag": DragParams;
-        "dragstart": DragEventParams; // Native (new-style) drag
+        "dragstart": DragComponentParams; // Native (new-style) drag
         "dragend": DragEventParams; // Native (new-style) drag
+        "drag-enter-window": DragEventParams; // Native (new-style) drag
+        "drag-leave-window": DragEventParams; // Native (new-style) drag
         "dragStart": DragStartParams; // Non-native (old-style) drag
         "dragStop": DragStopParams;
         "dragExported": ComponentItemParam;
@@ -226,6 +228,7 @@ export namespace EventEmitter {
     export type DragStopParams = [event: PointerEvent | undefined];
     export type DragParams = [offsetX: number, offsetY: number, event: PointerEvent];
     export type DragEventParams = [event: DragEvent];
+    export type DragComponentParams = [event: DragEvent, component: ComponentItem];
     export type BeforeComponentReleaseParams = [component: unknown];
     export type ClickBubblingEventParam = [ClickBubblingEvent];
     export type TouchStartBubblingEventParam = [TouchStartBubblingEvent];

--- a/src/ts/utils/utils.ts
+++ b/src/ts/utils/utils.ts
@@ -51,6 +51,12 @@ export function setElementDisplayVisibility(element: HTMLElement, visible: boole
 }
 
 /** @internal */
+export function enableIFramePointerEvents(enable: boolean) {
+    document.querySelectorAll('iframe.lm_content').forEach((element) =>
+        (element as HTMLElement).style.setProperty('pointer-events', enable ? '' : 'none'));
+}
+
+/** @internal */
 export function ensureElementPositionAbsolute(element: HTMLElement): void {
     const absolutePosition = 'absolute';
     if (element.style.position !== absolutePosition) {

--- a/src/ts/utils/utils.ts
+++ b/src/ts/utils/utils.ts
@@ -51,7 +51,7 @@ export function setElementDisplayVisibility(element: HTMLElement, visible: boole
 }
 
 /** @internal */
-export function enableIFramePointerEvents(enable: boolean) {
+export function enableIFramePointerEvents(enable: boolean): void {
     document.querySelectorAll('iframe.lm_content').forEach((element) =>
         (element as HTMLElement).style.setProperty('pointer-events', enable ? '' : 'none'));
 }

--- a/src/ts/virtual-layout.ts
+++ b/src/ts/virtual-layout.ts
@@ -280,6 +280,11 @@ export namespace VirtualLayout {
         containerOrBindComponentEventHandler?: HTMLElement |  VirtualLayout.BindComponentEventHandler):
         LayoutManager.ConstructorParameters
     {
+        if (typeof configOrOptionalContainer === 'object'
+            && ! (configOrOptionalContainer instanceof HTMLElement)
+            && configOrOptionalContainer.settings
+            && configOrOptionalContainer.settings.checkGlWindowKey === false)
+            subWindowChecked = true;
         const windowConfigKey = subWindowChecked ? null : new URL(document.location.href).searchParams.get('gl-window');
         subWindowChecked = true;
         const isSubWindow = windowConfigKey !== null;

--- a/test/specs/drag-tests.ts
+++ b/test/specs/drag-tests.ts
@@ -42,7 +42,7 @@ describe('drag source', function() {
 	function createDragSource(deferred: boolean): void {
 		dragSourceElement = document.createElement('div');
 		dragSourceElement.id = 'dragSrc';
-		dragSourceElement.setAttribute('draggable', 'yes');
+		dragSourceElement.setAttribute('draggable', 'true');
 		document.body.appendChild(dragSourceElement);
 
 		const componentType = TestTools.TEST_COMPONENT_NAME;

--- a/test/specs/drag-tests.ts
+++ b/test/specs/drag-tests.ts
@@ -42,6 +42,7 @@ describe('drag source', function() {
 	function createDragSource(deferred: boolean): void {
 		dragSourceElement = document.createElement('div');
 		dragSourceElement.id = 'dragSrc';
+		dragSourceElement.setAttribute('draggable', 'yes');
 		document.body.appendChild(dragSourceElement);
 
 		const componentType = TestTools.TEST_COMPONENT_NAME;

--- a/test/specs/event-emitter-tests.ts
+++ b/test/specs/event-emitter-tests.ts
@@ -48,10 +48,12 @@ describe( 'the EventEmitter', function(){
 		expect(myListener.allCallback ).toHaveBeenCalledWith('titleChanged', 'Good Morning');
 		expect(allCallbackSpy.calls.count()).toEqual(1);
 
+                /*
 		myObject.emit( 'dragStart', 123, 456 );
 		expect(titleCallbackSpy.calls.count()).toEqual(1);
 		expect(myListener.allCallback ).toHaveBeenCalledWith('dragStart', 123, 456);
 		expect(allCallbackSpy.calls.count()).toEqual(2);
+                */
 	});
 
 	it( 'unbinds events', function(){


### PR DESCRIPTION
I have a usable prototype using the HTML drag-and-drop. It supports (with some glitches):

* Drag from one window and drop to another.
* Drag from one window and drop to desktop as new window (popout).
* Cancel a drag (usually by typing Escape before releasing mouse).

I have not tested "virtual components" - but they are less needed because I changed things so non-virtual components are allocated under the top-level `body`, not the in the item tree. (I'm still interested in using virtual components to control widgets that are separate windows but that has to wait.)

The code needs work and the API is not stable. There are some incompatibilities - code written for the GL 2.x will not work, though it should be possible to fix that.

This builds on the  'tab-renderer' branch (PR #759).

This is used by the `drag-drop` branch of [DomTerm](https://github.com/PerBothner/DomTerm/).
