### PR TITLE
Popout URL redirect to handle hashes correctly

### DIFF
--- a/src/ts/controls/browser-popout.ts
+++ b/src/ts/controls/browser-popout.ts
@@ -285,9 +285,7 @@ export class BrowserPopout extends EventEmitter {
             throw new Error('Error while writing to localStorage ' + getErrorMessage(e));
         }
 
-        const url = new URL(location.href);
-        url.searchParams.set('gl-window', storageKey);
-        return url.toString();
+        return `${location.href}/?gl-window=${storageKey}`;
     }
 
     /**


### PR DESCRIPTION
Addresses issue [#809](https://github.com/golden-layout/golden-layout/issues/809),

Popout redirect fails with hash. We have an Angular App that uses hash's in the router, when popping out a window, the reloaded url is wrong.

New behaviour:
On popout, redirects : `our_domain.com/path/#/dashboard?gl-window=gl-window-config-124etc`

Old behaviour:
On popout, redirects, `our_domain.com/path/?gli-window=gl-window-config-124etc#/dashboard` (invalid url)