### PR TITLE
Don't minimise when adding item to currently maximised stack.

### DIFF
--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -279,7 +279,9 @@ export class Stack extends ComponentParentableItem {
     }
 
     addItem(itemConfig: ComponentItemConfig, index?: number): number {
-        this.layoutManager.checkMinimiseMaximisedStack();
+        if (!this.isMaximised) {
+            this.layoutManager.checkMinimiseMaximisedStack();
+        }
 
         const resolvedItemConfig = ItemConfig.resolve(itemConfig, false);
         const contentItem = this.layoutManager.createAndInitContentItem(resolvedItemConfig, this);


### PR DESCRIPTION
Currently, if a stack is maximized and you add an item to it, the stack will minimize itself. Ideally, you should be able to add an item to the maximized stack without minimizing it.