### PR TITLE
[v3] Intercept stack close event 

### DIFF
--- a/src/ts/config/config.ts
+++ b/src/ts/config/config.ts
@@ -1,5 +1,7 @@
 import { ConfigurationError } from '../errors/external-error';
 import { AssertError, UnexpectedUndefinedError, UnreachableCaseError } from '../errors/internal-error';
+import { ComponentItem } from '../items/component-item';
+import { Stack } from '../items/stack';
 import { I18nStringId, i18nStrings } from '../utils/i18n-strings';
 import { ItemType, JsonValue, ResponsiveMode, Side, SizeUnitEnum } from '../utils/types';
 import { deepExtendValue, splitStringAtFirstNonNumericChar } from '../utils/utils';
@@ -257,6 +259,7 @@ export namespace HeaderedItemConfig {
         close?: string;
         minimise?: string;
         tabDropdown?: false | string;
+        tabsContainerCloseInterceptor?: (stack: Stack) => Promise<boolean> | boolean;
     }
 
     export namespace Header {
@@ -271,6 +274,7 @@ export namespace HeaderedItemConfig {
                     close: header?.close,
                     minimise: header?.minimise,
                     tabDropdown: header?.tabDropdown,
+                    tabsContainerCloseInterceptor: header?.tabsContainerCloseInterceptor
                 }
                 return result;
             }
@@ -829,6 +833,13 @@ export namespace LayoutConfig {
          * Default: true
          */
         checkGlWindowKey?: boolean;
+
+        /**
+         * Intercepts tabs container close event
+         * @param componentItem
+         * @returns 
+         */
+        tabsContainerCloseInterceptor?: (stack: Stack) => Promise<boolean> | boolean;
     }
 
     export namespace Settings {
@@ -849,6 +860,7 @@ export namespace LayoutConfig {
                 reorderOnTabMenuClick: settings?.reorderOnTabMenuClick ?? ResolvedLayoutConfig.Settings.defaults.reorderOnTabMenuClick,
                 tabControlOffset: settings?.tabControlOffset ?? ResolvedLayoutConfig.Settings.defaults.tabControlOffset,
                 popInOnClose: settings?.popInOnClose ?? ResolvedLayoutConfig.Settings.defaults.popInOnClose,
+                tabsContainerCloseInterceptor: settings?.tabsContainerCloseInterceptor
             }
             return result;
         }
@@ -1074,6 +1086,7 @@ export namespace LayoutConfig {
                     (settings?.showCloseIcon === false ? false : ResolvedLayoutConfig.Header.defaults.close),
                 minimise: header?.minimise ?? labels?.minimise ?? ResolvedLayoutConfig.Header.defaults.minimise,
                 tabDropdown: header?.tabDropdown ?? labels?.tabDropdown ?? ResolvedLayoutConfig.Header.defaults.tabDropdown,
+                tabsContainerCloseInterceptor: undefined
             }
             return result;
         }

--- a/src/ts/config/resolved-config.ts
+++ b/src/ts/config/resolved-config.ts
@@ -1,4 +1,6 @@
 import { AssertError, UnreachableCaseError } from '../errors/internal-error';
+import { ComponentItem } from '../items/component-item';
+import { Stack } from '../items/stack';
 import { ConfigMinifier } from '../utils/config-minifier';
 import { ItemType, JsonValue, ResponsiveMode, Side, SizeUnitEnum } from '../utils/types';
 import { deepExtendValue } from '../utils/utils';
@@ -27,7 +29,7 @@ export namespace ResolvedItemConfig {
         minSize: undefined,
         minSizeUnit: SizeUnitEnum.Pixel,
         id: '',
-        isClosable: true,
+        isClosable: true
     } as const;
 
     /** Creates a copy of the original ResolvedItemConfig using an alternative content if specified */
@@ -102,6 +104,7 @@ export namespace ResolvedHeaderedItemConfig {
         readonly close: string | undefined;
         readonly minimise: string | undefined;
         readonly tabDropdown: false | string | undefined;
+        readonly tabsContainerCloseInterceptor?: (stack: Stack) => Promise<boolean> | boolean;
     }
 
     export namespace Header {
@@ -116,6 +119,7 @@ export namespace ResolvedHeaderedItemConfig {
                     maximise: original.maximise,
                     minimise: original.minimise,
                     tabDropdown: original.tabDropdown,
+                    tabsContainerCloseInterceptor: original.tabsContainerCloseInterceptor
                 }
             }
         }
@@ -146,7 +150,7 @@ export namespace ResolvedStackItemConfig {
             maximised: original.maximised,
             isClosable: original.isClosable,
             activeItemIndex: original.activeItemIndex,
-            header: ResolvedHeaderedItemConfig.Header.createCopy(original.header),
+            header: ResolvedHeaderedItemConfig.Header.createCopy(original.header)
         }
         return result;
     }
@@ -172,7 +176,7 @@ export namespace ResolvedStackItemConfig {
             maximised: ResolvedHeaderedItemConfig.defaultMaximised,
             isClosable: ResolvedItemConfig.defaults.isClosable,
             activeItemIndex: defaultActiveItemIndex,
-            header: undefined,
+            header: undefined
         }
         return result;
     }
@@ -220,7 +224,7 @@ export namespace ResolvedComponentItemConfig {
             title: original.title,
             header: ResolvedHeaderedItemConfig.Header.createCopy(original.header),
             componentType: original.componentType,
-            componentState: deepExtendValue(undefined, original.componentState) as JsonValue,
+            componentState: deepExtendValue(undefined, original.componentState) as JsonValue
         }
         return result;
     }
@@ -240,7 +244,7 @@ export namespace ResolvedComponentItemConfig {
             title,
             header: undefined,
             componentType,
-            componentState,
+            componentState
         }
         return result;
     }
@@ -288,7 +292,7 @@ export namespace ResolvedRowOrColumnItemConfig {
             minSize: original.minSize,
             minSizeUnit: original.minSizeUnit,
             id: original.id,
-            isClosable: original.isClosable,
+            isClosable: original.isClosable
         }
         return result;
     }
@@ -311,7 +315,7 @@ export namespace ResolvedRowOrColumnItemConfig {
             minSize: ResolvedItemConfig.defaults.minSize,
             minSizeUnit: ResolvedItemConfig.defaults.minSizeUnit,
             id: ResolvedItemConfig.defaults.id,
-            isClosable: ResolvedItemConfig.defaults.isClosable,
+            isClosable: ResolvedItemConfig.defaults.isClosable
         }
         return result;
     }
@@ -374,7 +378,7 @@ export namespace ResolvedGroundItemConfig {
             id: '',
             isClosable: false,
             title: '',
-            reorderEnabled: false,
+            reorderEnabled: false
         }
     }
 }
@@ -409,6 +413,7 @@ export namespace ResolvedLayoutConfig {
         readonly reorderOnTabMenuClick: boolean;
         readonly tabControlOffset: number;
         readonly popInOnClose: boolean;
+        readonly tabsContainerCloseInterceptor?: (stack: Stack) => Promise<boolean> | boolean;
     }
 
     export namespace Settings {
@@ -428,6 +433,7 @@ export namespace ResolvedLayoutConfig {
             reorderOnTabMenuClick: true,
             tabControlOffset: 10,
             popInOnClose: false,
+            tabsContainerCloseInterceptor: undefined
         } as const;
 
         export function createCopy(original: Settings): Settings {
@@ -447,6 +453,7 @@ export namespace ResolvedLayoutConfig {
                 reorderOnTabMenuClick: original.reorderOnTabMenuClick,
                 tabControlOffset: original.tabControlOffset,
                 popInOnClose: original.popInOnClose,
+                tabsContainerCloseInterceptor: original.tabsContainerCloseInterceptor
             }
         }
     }
@@ -503,6 +510,7 @@ export namespace ResolvedLayoutConfig {
         readonly minimise: string;
         readonly close: false | string;
         readonly tabDropdown: false | string;
+        readonly tabsContainerCloseInterceptor?: (stack: Stack) => Promise<boolean> | boolean;
     }
 
     export namespace Header {
@@ -515,6 +523,7 @@ export namespace ResolvedLayoutConfig {
                 maximise: original.maximise,
                 minimise: original.minimise,
                 tabDropdown: original.tabDropdown,
+                tabsContainerCloseInterceptor: original.tabsContainerCloseInterceptor
             }
         }
 
@@ -525,7 +534,8 @@ export namespace ResolvedLayoutConfig {
             maximise: 'maximise',
             minimise: 'minimise',
             close: 'close',
-            tabDropdown: 'additional tabs'
+            tabDropdown: 'additional tabs',
+            tabsContainerCloseInterceptor: undefined
         } as const;
     }
 
@@ -555,7 +565,7 @@ export namespace ResolvedLayoutConfig {
                 settings: ResolvedLayoutConfig.Settings.createCopy(config.settings),
                 dimensions: ResolvedLayoutConfig.Dimensions.createCopy(config.dimensions),
                 header: ResolvedLayoutConfig.Header.createCopy(config.header),
-                resolved: config.resolved,
+                resolved: config.resolved
             }
             return result;
         }

--- a/src/ts/controls/tabs-container.ts
+++ b/src/ts/controls/tabs-container.ts
@@ -6,8 +6,12 @@ import { DragListener } from '../utils/drag-listener';
 import { numberToPixels, pixelsToNumber } from '../utils/utils';
 import { Tab } from './tab';
 import { Header } from './header';
+import { Stack } from '../items/stack';
 
-/** @internal */
+/**
+ * Container of one or more taabs
+ * @internal
+ */
 export class TabsContainer {
     // There is one tab per ComponentItem in stack.  However they may not be ordered the same
     private readonly _tabs: Tab[] = [];
@@ -30,6 +34,7 @@ export class TabsContainer {
         private _componentFocusEvent: TabsContainer.ComponentItemFocusEvent,
         private _componentDragStartEvent: TabsContainer.ComponentItemDragStartEvent,
         private _dropdownActiveChangedEvent: TabsContainer.DropdownActiveChangedEvent,
+        private _tabsContainerCloseInterceptor?: (stack: Stack) => Promise<boolean> | boolean
     ) {
         this._element = document.createElement('section');
         this._element.classList.add(DomConstants.ClassName.Tabs);
@@ -62,7 +67,8 @@ export class TabsContainer {
             componentItem,
             (item) => this.handleTabCloseEvent(item),
             (item) => this.handleTabFocusEvent(item),
-            (x, y, dragListener, item) => this.handleTabDragStartEvent(x, y, dragListener, item));
+            (x, y, dragListener, item) => this.handleTabDragStartEvent(x, y, dragListener, item), 
+            this);
 
         if (index === undefined) {
             index = this._tabs.length;

--- a/src/ts/items/component-item.ts
+++ b/src/ts/items/component-item.ts
@@ -110,7 +110,7 @@ export class ComponentItem extends ContentItem {
             title: this._title,
             header: ResolvedHeaderedItemConfig.Header.createCopy(this._headerConfig),
             componentType: ResolvedComponentItemConfig.copyComponentType(this.componentType),
-            componentState: state,
+            componentState: state
         }
 
         return result;
@@ -172,7 +172,6 @@ export class ComponentItem extends ContentItem {
      * @public
      * @param title -
      */
-
     setTitle(title: string): void {
         this._title = title;
         this.emit('titleChanged', title);

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -88,7 +88,10 @@ export class Stack extends ComponentParentableItem {
         const close = this._headerConfig?.close ?? componentHeaderConfig?.close ?? layoutHeaderConfig.close;
         const minimise = this._headerConfig?.minimise ?? componentHeaderConfig?.minimise ?? layoutHeaderConfig.minimise;
         const tabDropdown = this._headerConfig?.tabDropdown ?? componentHeaderConfig?.tabDropdown ?? layoutHeaderConfig.tabDropdown;
+        const tabsContainerCloseInterceptor = this._headerConfig?.tabsContainerCloseInterceptor ?? componentHeaderConfig?.tabsContainerCloseInterceptor ?? layoutHeaderConfig.tabsContainerCloseInterceptor;
         this._maximisedEnabled = maximise !== false;
+
+
         const headerSettings: Header.Settings = {
             show: show !== false,
             side: show === false ? Side.top : show,
@@ -102,20 +105,24 @@ export class Stack extends ComponentParentableItem {
             minimiseLabel: minimise,
             tabDropdownEnabled: tabDropdown !== false,
             tabDropdownLabel: tabDropdown === false ? '' : tabDropdown,
+            tabsContainerCloseInterceptor: tabsContainerCloseInterceptor
         };
 
-        this._header = new Header(layoutManager,
-            this, headerSettings,
+        this._header = new Header(
+            layoutManager,
+            this, 
+            headerSettings,
             config.isClosable && close !== false,
             () => this.getActiveComponentItem(),
-            () => this.remove(),
+            () => this.removeHeader(this),
             () => this.handlePopoutEvent(),
             () => this.toggleMaximise(),
             (ev) => this.handleHeaderClickEvent(ev),
             (ev) => this.handleHeaderTouchStartEvent(ev),
             (item) => this.handleHeaderComponentRemoveEvent(item),
             (item) => this.handleHeaderComponentFocusEvent(item),
-            (x, y, dragListener, item) => this.handleHeaderComponentStartDragEvent(x, y, dragListener, item),
+            (x, y, dragListener, item) => this.handleHeaderComponentStartDragEvent(x, y, dragListener, item)
+
         );
 
         // this._dropZones = {};
@@ -403,7 +410,7 @@ export class Stack extends ComponentParentableItem {
                 isClosable: this.isClosable,
                 maximised: this.isMaximised,
                 header: this.createHeaderConfig(),
-                activeItemIndex,
+                activeItemIndex
             }
             return result;
         }
@@ -913,6 +920,7 @@ export class Stack extends ComponentParentableItem {
                     close: undefined,
                     minimise: undefined,
                     tabDropdown: undefined,
+                    tabsContainerCloseInterceptor: () => true
                 };
             }
             return result;


### PR DESCRIPTION
This is an early draft I'm opening to probe whether @PerBothner would be open to merge this once I clean this up (the mess this currently is, is due to me making sense of how the *** config / resolved config system works)

In our use case (Blazor server), whenever the user attempts to close a stack, we need to ping the server and get a response, whether to warn about potentially losing unsaved changes (by checking for unsaved changes in each tab the stack owns).

This adds a setting which allows this, used as:

```ts
const layout : LayoutConfig = {
  settings: {
      tabsContainerCloseInterceptor: async (x) => { // Promise<boolean> | boolean
          // await some work
          return false;
      }
  }
};
```

> Since upstream is inactive, I see no point in creating clean pull requests. Likewise, documenting my changes or cleaning up the APIs is not a priority unless I see signs of actual users. If you do want to use my fork, feel free to create an Issue or email me if you need help - that may spur me to clean things up a bit.

Let this also be a sign that v3 is being adopted and any docs about it would be very appreciated!